### PR TITLE
[ADD] Apple SD Gothic Neo 폰트를 Extension 파일로 추가합니다.

### DIFF
--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		B5BE347B28FD9E5500D09BEE /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347A28FD9E5500D09BEE /* UIViewController+Alert.swift */; };
 		B5BE347E28FDA22F00D09BEE /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347D28FDA22F00D09BEE /* ImageLiteral.swift */; };
 		B5BE348028FDA2A200D09BEE /* StringLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347F28FDA2A200D09BEE /* StringLiteral.swift */; };
+		B5FAC8EB2907BA6000537F58 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8EA2907BA6000537F58 /* UIFont+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		B5BE347A28FD9E5500D09BEE /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		B5BE347D28FDA22F00D09BEE /* ImageLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		B5BE347F28FDA2A200D09BEE /* StringLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiteral.swift; sourceTree = "<group>"; };
+		B5FAC8EA2907BA6000537F58 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -238,6 +240,7 @@
 				B5BE347128FD9C9A00D09BEE /* UIViewController+Extension.swift */,
 				B5BE347328FD9CD200D09BEE /* UIView+Extension.swift */,
 				B5BE347528FD9CF800D09BEE /* UIButton+Extension.swift */,
+				B5FAC8EA2907BA6000537F58 /* UIFont+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				B5BE345E28FD982700D09BEE /* MyNewsViewController.swift in Sources */,
 				B5BE347628FD9CF800D09BEE /* UIButton+Extension.swift in Sources */,
 				B5BE346A28FD9AEC00D09BEE /* UIColor+Extension.swift in Sources */,
+				B5FAC8EB2907BA6000537F58 /* UIFont+Extension.swift in Sources */,
 				B5BE346228FD985500D09BEE /* NewsViewController.swift in Sources */,
 				B5BE346428FD986600D09BEE /* NewsFeedViewController.swift in Sources */,
 				B5BE346C28FD9B7900D09BEE /* NSObject+Extension.swift in Sources */,

--- a/EarthValley80/EarthValley80/Global/Extensions/UIFont+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UIFont+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  UIFont+Extension.swift
+//  EarthValley80
+//
+//  Created by SHIN YOON AH on 2022/10/25.
+//
+
+import UIKit
+
+enum FontName: String {
+    case regular = "AppleSDGothicNeo-Regular"
+    case medium = "AppleSDGothicNeo-Medium"
+    case semibold = "AppleSDGothicNeo-SemiBold"
+    case bold = "AppleSDGothicNeo-Bold"
+}
+
+extension UIFont {
+    static func font(_ style: FontName, ofSize size: CGFloat) -> UIFont {
+        return UIFont(name: style.rawValue, size: size)!
+    }
+}


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #17 

## ⚫️  변경사항
<!-- 의존성 목록 -->

## ⚫️  새로운 기능
<!-- 기능 목록 -->
`UIFont+Extension` 내부에 Apple SD Gothic Neo를 쉽게 사용할 수 있는 `font` 함수를 추가했습니다.
매번 Apple SD Gothic Neo Family Set를 사용하려면 FamilyName에 해당 이름을 넣어줘야 하는데 그런 귀찮은 일을 덜어내기 위해서 함수를 만들었습니다.

**사용법 :**
```swift
label.font = .font(.bold, ofSize: 32)
```

다양한 Style이 있는데 베리에게 물어본 결과, `regular`, `medium`, `semibold`, `bold`만 사용한다고 해서 해당 Style만 넣었습니다.

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
