### PR TITLE
[FEAT] 테이블 뷰가 스크롤될 시에 상단 헤더 모양이 변경되도록 구현했습니다.

### DIFF
--- a/EarthValley80/EarthValley80/Global/Resource/Storyboard/News.storyboard
+++ b/EarthValley80/EarthValley80/Global/Resource/Storyboard/News.storyboard
@@ -9,21 +9,6 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--News View Controller-->
-        <scene sceneID="s0d-6b-0kx">
-            <objects>
-                <viewController storyboardIdentifier="NewsViewController" id="Y6W-OH-hqX" customClass="NewsViewController" customModule="EarthValley80" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="76" y="-2"/>
-        </scene>
         <!--Reading News View Controller-->
         <scene sceneID="Hwb-cM-Lpb">
             <objects>

--- a/EarthValley80/EarthValley80/Global/Supports/Info.plist
+++ b/EarthValley80/EarthValley80/Global/Supports/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>NewsFeed</string>
+					<string>News</string>
 				</dict>
 			</array>
 		</dict>

--- a/EarthValley80/EarthValley80/Global/Supports/Info.plist
+++ b/EarthValley80/EarthValley80/Global/Supports/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>News</string>
+					<string>NewsFeed</string>
 				</dict>
 			</array>
 		</dict>

--- a/EarthValley80/EarthValley80/Global/Utils/UIView+Constraints.swift
+++ b/EarthValley80/EarthValley80/Global/Utils/UIView+Constraints.swift
@@ -12,20 +12,27 @@ enum ConstraintType {
 }
 
 extension UIView {
+    
     enum Frame {
-        case widthAnchor
-        case heightAnchor
+        case widthAnchor, heightAnchor
     }
     
-    func constraint(_ anchor: Frame, constant: CGFloat) {
+    @discardableResult
+    func constraint(_ anchor: Frame, constant: CGFloat) -> [Frame: NSLayoutConstraint] {
+        var constraints: [Frame: NSLayoutConstraint] = [:]
+        
         self.translatesAutoresizingMaskIntoConstraints = false
         
         switch anchor {
         case .widthAnchor:
-            self.widthAnchor.constraint(equalToConstant: constant).isActive = true
+            constraints[.widthAnchor] = self.widthAnchor.constraint(equalToConstant: constant)
         case .heightAnchor:
-            self.heightAnchor.constraint(equalToConstant: constant).isActive = true
+            constraints[.heightAnchor] = self.heightAnchor.constraint(equalToConstant: constant)
         }
+        
+        let constraintsArray: [NSLayoutConstraint] = Array(constraints.values)
+        NSLayoutConstraint.activate(constraintsArray)
+        return constraints
     }
     
     func constraint(to view: UIView, insets: UIEdgeInsets = .zero) {

--- a/EarthValley80/EarthValley80/Global/Utils/UIView+Constraints.swift
+++ b/EarthValley80/EarthValley80/Global/Utils/UIView+Constraints.swift
@@ -11,12 +11,11 @@ enum ConstraintType {
     case top, leading, trailing, bottom, centerX, centerY
 }
 
+enum Frame {
+    case widthAnchor, heightAnchor
+}
+
 extension UIView {
-    
-    enum Frame {
-        case widthAnchor, heightAnchor
-    }
-    
     @discardableResult
     func constraint(_ anchor: Frame, constant: CGFloat) -> [Frame: NSLayoutConstraint] {
         var constraints: [Frame: NSLayoutConstraint] = [:]

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -15,8 +15,9 @@ final class NewsTitleView: UIView {
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
         static let questionViewPadding: CGFloat = 16.0
-        static let bottomSpacing: CGFloat = 50.0
-        static let minimumBottomSpacing: CGFloat = 40.0
+        static let originalBottomSpacing: CGFloat = 50.0
+        static let scrolledBottomSpacing: CGFloat = 40.0
+        static let minimumBottomSpacing: CGFloat = 24.0
     }
     
     enum Status {
@@ -53,10 +54,12 @@ final class NewsTitleView: UIView {
         
         var bottomSpacing: CGFloat {
             switch self {
+            case .expanded:
+                return Size.originalBottomSpacing
             case .scrolled:
+                return Size.scrolledBottomSpacing
+            case .compact:
                 return Size.minimumBottomSpacing
-            default:
-                return Size.bottomSpacing
             }
         }
     }
@@ -112,10 +115,13 @@ final class NewsTitleView: UIView {
     
     private func setupLayout() {
         self.addSubview(self.titleLabel)
-        self.titleLabel.constraint(top: self.topAnchor,
-                                   leading: self.leadingAnchor,
-                                   trailing: self.trailingAnchor,
-                                   padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: 0, right: self.status.horizontalPadding))
+        let labelConstraint = self.titleLabel.constraint(top: self.topAnchor,
+                                                         leading: self.leadingAnchor,
+                                                         bottom: self.bottomAnchor,
+                                                         trailing: self.trailingAnchor,
+                                                         padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: self.status.bottomSpacing, right: self.status.horizontalPadding))
+        
+        labelConstraint[.bottom]?.isActive = self.status == .compact
     }
     
     func updateTitleStatus(to status: Status) {

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -15,6 +15,7 @@ final class NewsTitleView: UIView {
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
         static let questionViewPadding: CGFloat = 16.0
+        static let bottomSpacing: CGFloat = 40.0
     }
     
     enum Status {
@@ -96,5 +97,18 @@ final class NewsTitleView: UIView {
     
     func updateTitleStatus(to status: Status) {
         self.status = status
+    }
+    
+    func heightOfTitleView() -> CGFloat {
+        let text = self.titleLabel.text
+        let label = UILabel()
+        
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .font(.bold, ofSize: self.status.fontSize)
+        label.setLineSpacing(kernValue: -2.0, lineHeightMultiple: 1.16)
+        label.sizeToFit()
+        
+        return label.frame.height + Size.bottomSpacing * 2
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -12,8 +12,6 @@ final class NewsTitleView: UIView {
     private enum Size {
         static let horizontalPadding: CGFloat = 96.0
         static let minimumHorizontalPadding: CGFloat = 56.0
-        static let verticalPadding: CGFloat = 40.0
-        static let minimumVerticalPadding: CGFloat = 20.0
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
         static let questionViewPadding: CGFloat = 16.0
@@ -33,21 +31,21 @@ final class NewsTitleView: UIView {
             }
         }
         
+        var textColor: UIColor {
+            switch self {
+            case .scrolled:
+                return .evyWhite.withAlphaComponent(0.4)
+            default:
+                return .evyWhite
+            }
+        }
+        
         var horizontalPadding: CGFloat {
             switch self {
             case .compact:
                 return Size.minimumHorizontalPadding
             default:
                 return Size.horizontalPadding
-            }
-        }
-        
-        var verticalPadding: CGFloat {
-            switch self {
-            case .expanded:
-                return Size.verticalPadding
-            default:
-                return Size.minimumVerticalPadding
             }
         }
     }
@@ -61,39 +59,24 @@ final class NewsTitleView: UIView {
         label.text = "인류보다 로봇 진화 속도가 더 빠르대요, 청소로봇은 '루시'…생각하는 로봇 등장"
         label.numberOfLines = 0
         label.textColor = .white
-        label.font = .font(.bold, ofSize: status.fontSize)
+        label.font = .font(.bold, ofSize: self.status.fontSize)
         label.setLineSpacing(kernValue: -2.0, lineHeightMultiple: 1.16)
         return label
     }()
     
     private var status: Status {
         willSet {
-            titleLabel.font = .font(.bold, ofSize: newValue.fontSize)
+            self.titleLabel.font = .font(.bold, ofSize: newValue.fontSize)
+            self.titleLabel.textColor = newValue.textColor
         }
     }
     
-    private var heightToFit: CGFloat {
-        let width = UIScreen.main.bounds.size.width - Size.questionViewPadding - (Size.horizontalPadding * 2)
-        let label = UILabel(frame: CGRectMake(0, 0, width, CGFloat.greatestFiniteMagnitude))
-        
-        label.numberOfLines = 0
-        label.lineBreakMode = NSLineBreakMode.byWordWrapping
-        label.font = .font(.bold, ofSize: self.status.fontSize)
-        label.text = self.titleLabel.text
-        label.sizeToFit()
-        
-        return label.frame.height
-    }
-    
-    private var titleConstraintConstant: [ConstraintType : NSLayoutConstraint]?
-
     // MARK: - init
     
     init(status: Status) {
         self.status = status
         super.init(frame: .zero)
         self.setupLayout()
-        backgroundColor = .blue
     }
     
     @available(*, unavailable)
@@ -105,19 +88,13 @@ final class NewsTitleView: UIView {
     
     private func setupLayout() {
         self.addSubview(self.titleLabel)
-        self.titleConstraintConstant = self.titleLabel.constraint(top: self.topAnchor,
-                                                                  leading: self.leadingAnchor,
-                                                                  bottom: self.bottomAnchor,
-                                                                  trailing: self.trailingAnchor,
-                                                                  padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: self.status.verticalPadding, right: self.status.horizontalPadding))
-    }
-    
-    private func updateLayout() {
-        self.titleConstraintConstant?[.bottom]?.constant = -self.status.verticalPadding
+        self.titleLabel.constraint(top: self.topAnchor,
+                                   leading: self.leadingAnchor,
+                                   trailing: self.trailingAnchor,
+                                   padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: 0, right: self.status.horizontalPadding))
     }
     
     func updateTitleStatus(to status: Status) {
         self.status = status
-        self.updateLayout()
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -13,9 +13,10 @@ final class NewsTitleView: UIView {
         static let horizontalPadding: CGFloat = 96.0
         static let minimumHorizontalPadding: CGFloat = 56.0
         static let verticalPadding: CGFloat = 40.0
-        static let minimumVeritcalPadding: CGFloat = 20.0
+        static let minimumVerticalPadding: CGFloat = 20.0
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
+        static let questionViewPadding: CGFloat = 16.0
     }
     
     enum Status {
@@ -46,7 +47,7 @@ final class NewsTitleView: UIView {
             case .expanded:
                 return Size.verticalPadding
             default:
-                return Size.minimumVeritcalPadding
+                return Size.minimumVerticalPadding
             }
         }
     }
@@ -68,8 +69,20 @@ final class NewsTitleView: UIView {
     private var status: Status {
         willSet {
             titleLabel.font = .font(.bold, ofSize: newValue.fontSize)
-            updateLayout()
         }
+    }
+    
+    private var heightToFit: CGFloat {
+        let width = UIScreen.main.bounds.size.width - Size.questionViewPadding - (Size.horizontalPadding * 2)
+        let label = UILabel(frame: CGRectMake(0, 0, width, CGFloat.greatestFiniteMagnitude))
+        
+        label.numberOfLines = 0
+        label.lineBreakMode = NSLineBreakMode.byWordWrapping
+        label.font = .font(.bold, ofSize: self.status.fontSize)
+        label.text = self.titleLabel.text
+        label.sizeToFit()
+        
+        return label.frame.height
     }
     
     private var titleConstraintConstant: [ConstraintType : NSLayoutConstraint]?
@@ -93,17 +106,18 @@ final class NewsTitleView: UIView {
     private func setupLayout() {
         self.addSubview(self.titleLabel)
         self.titleConstraintConstant = self.titleLabel.constraint(top: self.topAnchor,
-                                                                     leading: self.leadingAnchor,
-                                                                     bottom: self.bottomAnchor,
-                                                                     trailing: self.trailingAnchor,
-                                                                     padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: self.status.verticalPadding, right: self.status.horizontalPadding))
+                                                                  leading: self.leadingAnchor,
+                                                                  bottom: self.bottomAnchor,
+                                                                  trailing: self.trailingAnchor,
+                                                                  padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: self.status.verticalPadding, right: self.status.horizontalPadding))
     }
     
     private func updateLayout() {
-        self.titleConstraintConstant?[.bottom]?.constant = self.status.verticalPadding
+        self.titleConstraintConstant?[.bottom]?.constant = -self.status.verticalPadding
     }
     
     func updateTitleStatus(to status: Status) {
         self.status = status
+        self.updateLayout()
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -12,6 +12,8 @@ final class NewsTitleView: UIView {
     private enum Size {
         static let horizontalPadding: CGFloat = 96.0
         static let minimumHorizontalPadding: CGFloat = 56.0
+        static let verticalPadding: CGFloat = 40.0
+        static let minimumVeritcalPadding: CGFloat = 20.0
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
     }
@@ -19,22 +21,32 @@ final class NewsTitleView: UIView {
     enum Status {
         case expanded
         case compact
+        case scrolled
         
         var fontSize: CGFloat {
             switch self {
             case .expanded:
                 return Size.originalFontSize
-            case .compact:
+            default:
                 return Size.minimumFontSize
             }
         }
         
         var horizontalPadding: CGFloat {
             switch self {
-            case .expanded:
-                return Size.horizontalPadding
             case .compact:
                 return Size.minimumHorizontalPadding
+            default:
+                return Size.horizontalPadding
+            }
+        }
+        
+        var verticalPadding: CGFloat {
+            switch self {
+            case .expanded:
+                return Size.verticalPadding
+            default:
+                return Size.minimumVeritcalPadding
             }
         }
     }
@@ -53,7 +65,14 @@ final class NewsTitleView: UIView {
         return label
     }()
     
-    private let status: Status
+    private var status: Status {
+        willSet {
+            titleLabel.font = .font(.bold, ofSize: newValue.fontSize)
+            updateLayout()
+        }
+    }
+    
+    private var titleConstraintConstant: [ConstraintType : NSLayoutConstraint]?
 
     // MARK: - init
     
@@ -61,6 +80,7 @@ final class NewsTitleView: UIView {
         self.status = status
         super.init(frame: .zero)
         self.setupLayout()
+        backgroundColor = .blue
     }
     
     @available(*, unavailable)
@@ -72,7 +92,18 @@ final class NewsTitleView: UIView {
     
     private func setupLayout() {
         self.addSubview(self.titleLabel)
-        self.titleLabel.constraint(to: self,
-                                   insets: UIEdgeInsets(top: 0, left: status.horizontalPadding, bottom: -40, right: -status.horizontalPadding))
+        self.titleConstraintConstant = self.titleLabel.constraint(top: self.topAnchor,
+                                                                     leading: self.leadingAnchor,
+                                                                     bottom: self.bottomAnchor,
+                                                                     trailing: self.trailingAnchor,
+                                                                     padding: UIEdgeInsets(top: 0, left: self.status.horizontalPadding, bottom: self.status.verticalPadding, right: self.status.horizontalPadding))
+    }
+    
+    private func updateLayout() {
+        self.titleConstraintConstant?[.bottom]?.constant = self.status.verticalPadding
+    }
+    
+    func updateTitleStatus(to status: Status) {
+        self.status = status
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -15,7 +15,8 @@ final class NewsTitleView: UIView {
         static let originalFontSize: CGFloat = 54.0
         static let minimumFontSize: CGFloat = 40.0
         static let questionViewPadding: CGFloat = 16.0
-        static let bottomSpacing: CGFloat = 40.0
+        static let bottomSpacing: CGFloat = 50.0
+        static let minimumBottomSpacing: CGFloat = 40.0
     }
     
     enum Status {
@@ -49,6 +50,15 @@ final class NewsTitleView: UIView {
                 return Size.horizontalPadding
             }
         }
+        
+        var bottomSpacing: CGFloat {
+            switch self {
+            case .scrolled:
+                return Size.minimumBottomSpacing
+            default:
+                return Size.bottomSpacing
+            }
+        }
     }
     
     // MARK: - property
@@ -70,6 +80,19 @@ final class NewsTitleView: UIView {
             self.titleLabel.font = .font(.bold, ofSize: newValue.fontSize)
             self.titleLabel.textColor = newValue.textColor
         }
+    }
+    
+    var heightOfLabel: CGFloat {
+        let label = UILabel()
+        let text = self.titleLabel.text
+        
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .font(.bold, ofSize: self.status.fontSize)
+        label.setLineSpacing(kernValue: -2.0, lineHeightMultiple: 1.16)
+        label.sizeToFit()
+        
+        return label.frame.height + self.status.bottomSpacing * 2
     }
     
     // MARK: - init
@@ -97,18 +120,5 @@ final class NewsTitleView: UIView {
     
     func updateTitleStatus(to status: Status) {
         self.status = status
-    }
-    
-    func heightOfTitleView() -> CGFloat {
-        let text = self.titleLabel.text
-        let label = UILabel()
-        
-        label.text = text
-        label.numberOfLines = 0
-        label.font = .font(.bold, ofSize: self.status.fontSize)
-        label.setLineSpacing(kernValue: -2.0, lineHeightMultiple: 1.16)
-        label.sizeToFit()
-        
-        return label.frame.height + Size.bottomSpacing * 2
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/FiveWsAndOneHViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/FiveWsAndOneHViewController.swift
@@ -27,7 +27,6 @@ final class FiveWsAndOneHViewController: UIViewController {
     private lazy var newsTableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.dataSource = self
-        tableView.delegate = self
         tableView.backgroundColor = .clear
         tableView.separatorColor = .clear
         tableView.indicatorStyle = .white
@@ -79,12 +78,18 @@ final class FiveWsAndOneHViewController: UIViewController {
                                      leading: self.view.leadingAnchor,
                                      padding: UIEdgeInsets(top: 76, left: 56, bottom: 0, right: 0))
         
+        self.view.addSubview(self.titleHeaderView)
+        self.titleHeaderView.constraint(top: self.captionLabel.bottomAnchor,
+                                      leading: self.view.leadingAnchor,
+                                      trailing: self.questionView.leadingAnchor,
+                                      padding: UIEdgeInsets(top: 12, left: 0, bottom: 0, right: 10))
+        
         self.view.addSubview(self.newsTableView)
-        self.newsTableView.constraint(top: self.captionLabel.bottomAnchor,
+        self.newsTableView.constraint(top: self.titleHeaderView.bottomAnchor,
                                       leading: self.view.leadingAnchor,
                                       bottom: self.view.bottomAnchor,
                                       trailing: self.questionView.leadingAnchor,
-                                      padding: UIEdgeInsets(top: 12, left: 0, bottom: 0, right: 10))
+                                      padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10))
     }
     
     private func configureUI() {
@@ -103,12 +108,5 @@ extension FiveWsAndOneHViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: NewsContentTableViewCell.className) as? NewsContentTableViewCell else { return UITableViewCell() }
         cell.status = .compact
         return cell
-    }
-}
-
-// MARK: - UITableViewDelegate
-extension FiveWsAndOneHViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return self.titleHeaderView
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
@@ -74,6 +74,7 @@ final class ReadingNewsViewController: UIViewController {
     
     private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.didTappedView(_:)))
     private var questionViewConstraints: [ConstraintType: NSLayoutConstraint]?
+    private var headerFrameConstraints: [Frame: NSLayoutConstraint]?
     
     // MARK: - life cycle
 
@@ -108,7 +109,7 @@ final class ReadingNewsViewController: UIViewController {
                                         leading: self.view.leadingAnchor,
                                         trailing: self.questionView.leadingAnchor,
                                         padding: UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 0))
-        self.titleHeaderView.constraint(.heightAnchor, constant: self.titleHeaderView.heightOfTitleView())
+        self.headerFrameConstraints = self.titleHeaderView.constraint(.heightAnchor, constant: self.titleHeaderView.heightOfLabel)
         
         self.view.addSubview(self.newsTableView)
         self.newsTableView.constraint(top: self.titleHeaderView.bottomAnchor,
@@ -206,11 +207,9 @@ extension ReadingNewsViewController: UITableViewDataSource {
 extension ReadingNewsViewController: UITableViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
+        let isScrolled = offsetY > 0
         
-        if offsetY > 0 {
-            self.titleHeaderView.updateTitleStatus(to: .scrolled)
-        } else {
-            self.titleHeaderView.updateTitleStatus(to: .expanded)
-        }
+        self.titleHeaderView.updateTitleStatus(to: isScrolled ? .scrolled : .expanded)
+        self.headerFrameConstraints?[.heightAnchor]?.constant = self.titleHeaderView.heightOfLabel
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
@@ -200,4 +200,14 @@ extension ReadingNewsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return self.titleHeaderView
     }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offsetY = scrollView.contentOffset.y
+        
+        if offsetY > 0 {
+            self.titleHeaderView.updateTitleStatus(to: .scrolled)
+        } else {
+            self.titleHeaderView.updateTitleStatus(to: .expanded)
+        }
+    }
 }

--- a/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/ReadingNewsViewController.swift
@@ -103,12 +103,19 @@ final class ReadingNewsViewController: UIViewController {
                                      leading: self.view.leadingAnchor,
                                      padding: UIEdgeInsets(top: 76, left: 96, bottom: 0, right: 0))
         
+        self.view.addSubview(self.titleHeaderView)
+        self.titleHeaderView.constraint(top: self.captionLabel.bottomAnchor,
+                                        leading: self.view.leadingAnchor,
+                                        trailing: self.questionView.leadingAnchor,
+                                        padding: UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 0))
+        self.titleHeaderView.constraint(.heightAnchor, constant: self.titleHeaderView.heightOfTitleView())
+        
         self.view.addSubview(self.newsTableView)
-        self.newsTableView.constraint(top: self.captionLabel.bottomAnchor,
+        self.newsTableView.constraint(top: self.titleHeaderView.bottomAnchor,
                                       leading: self.view.leadingAnchor,
                                       bottom: self.view.bottomAnchor,
                                       trailing: self.questionView.leadingAnchor,
-                                      padding: UIEdgeInsets(top: 15, left: 0, bottom: 0, right: 10))
+                                      padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10))
         
         self.view.addSubview(self.nextButton)
         self.nextButton.constraint(bottom: self.view.bottomAnchor,
@@ -197,10 +204,6 @@ extension ReadingNewsViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension ReadingNewsViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return self.titleHeaderView
-    }
-    
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #43 

## ⚫️  변경사항
<!-- 의존성 목록 -->
#### 1️⃣ 사용하지 않는 `NewsViewController`를 삭제했습니다.
#### 2️⃣ `constraint` 함수 중 width, height를 잡는 함수에서 [Frame: NSLayoutConstraint]가 return 되도록 구현했습니다.

**why?**
다른 constraint를 보면 return되는 함수들이 있는데 이 함수들은 해당 값들을 뷰에서 다른 값으로 재조정할 수도 있고 그 값을 받아서 사용할 수도 있습니다. 제 뷰에서 header height를 재조정해줘야 했기에 해당 constraint 값을 return 해주는 부분이 필요했습니다. 따라서 return 값을 생성해줬고, `@discardableResult` 키워드를 넣어줬기 때문에 result를 사용하지 않아도 괜찮습니다.

<br/>

## ⚫️  새로운 기능
<!-- 기능 목록 -->

### ➰ 스크롤이 진행되면 header 상태를 바꿔주자

`scrollViewDidScroll`에서 `offset.y의 크기가 0 초과가 되면 스크롤이 되었다고 판단하여 header 상태를 변경해주었습니다.

상태 변경 플로우
* `offset.y > 0` -> headerView 내부의 status를 scrolled로 변경 -> status의 프로퍼티 옵져버 발동 -> label configuration 변경 -> headerFrameConstraints.constant 값을 headerView에 있는 title frame height로 변경해줌
* `offset.y <= 0` -> headerView 내부의 status를 expanded로 변경 -> status의 프로퍼티 옵져버 발동 -> label configuration 변경 -> headerFrameConstraints.constant 값을 headerView에 있는 title frame height로 변경해줌

<br/>

☑️ status 관련 부분은 titleHeaderView 내부에 있는 status enum 구조를 참고해주시면 됩니다. 변경되는 값들은 해당 enum에 최대한 반영해서 사용하려고 했습니다.

☑️ headerFrameConstraints를 사용한 이유는 headerView의 height를 변경하기 위해서 headerView를 처음 layout 잡았을 때 그 값을 가지고 있어야 해서 따로 선언해뒀습니다. 해당 값을 사용해서 headerView height를 조정하고 있습니다. 자세한 사항은 `constraint`내부에 있는 height, width constraint 잡는 부분을 확인해주시면 됩니다.

<br>

### ➰ 더이상 header가 TableView에 속하지 않습니다.

**why?**
header에 배경을 넣지 않으면 뒤가 불투명하게 비치는데 저희 그라데이션 배경을 어찌 적용할 것인가?에 대한 걱정 + 스크롤할 시에 header의 높이가 변경되어야 하는데 header 자체가 TableView에 속하다보니 TableView가 reload하지 않으면 높이가 바뀌지 않는 문제 등으로 TableView 헤더를 쓰는 것은 무리라고 생각이 들어서 밖으로 빼게 되었습니다.

어차피 레이아웃만 다시 잡아주면 되는 문제라서 큰 어려움은 없었습니다. 이걸 실행하기까지가 시간이 좀 오래걸렸을 뿐..🥲

<br/>

**세심하게 봐주세요**
해당 header는 ReadingNewsViewController와 5W1HViewController 부분에서 조금의 차이가 있습니다. 

* ReadingNewsViewController(.scrolled, .expanded)는 높이가 변경되는 것이 중요하기 때문에 HeaderView 내부에 있는 title의 bottom Anchor가 설정되어 있지 않아도 됩니다. 높이가 결정되는 것이 더 중요 + bottom Anchor가 설정되면 title이 중간 정렬되는 문제가 있기 때문

* 5W1HViewController(.compact)는 View의 frame를 잡는게 중요하기 때문에 HeaderView 내부에 있는 title의 bottom Anchor가 설정되어야 합니다. bottom이 없으면 높이가 애매해서 header 아래에 있는 TableView가 없어집니다. 

이런 두 가지 상황이 한 View에서 나타나야 해서 분기처리를 진행했습니다.
```swift
labelConstraint[.bottom]?.isActive = self.status == .compact
```

labelConstraint는 현재 titleLabel의 constraint를 가지고 있는 값이고 만약 5W1HViewController가 아니라면 해당 옵션이 꺼지도록 구현했습니다.

<br>

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

**[ReadingNewsViewController]**

https://user-images.githubusercontent.com/55099365/199277227-70448380-8db9-44cb-8ef9-719f59dceb62.mov

**[5W1HViewController]**

https://user-images.githubusercontent.com/55099365/199277614-f349735d-e430-4ac1-84f4-057dbecf47f6.mov



### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
