### PR TITLE
[ADD] 나의 뉴스 서랍에서 collectionview를 클릭하면 나오는 POP UP 뷰를 구현했습니다.

### DIFF
--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		381AB436290FC96900620635 /* GotoYomojomoNewsEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381AB435290FC96900620635 /* GotoYomojomoNewsEmptyView.swift */; };
 		381AB44829116D0D00620635 /* GotoSomewhereButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381AB44729116D0D00620635 /* GotoSomewhereButton.swift */; };
 		381AB44A2911726B00620635 /* mp4TempFile.json in Resources */ = {isa = PBXBuildFile; fileRef = 381AB4492911726B00620635 /* mp4TempFile.json */; };
+		3846FBFD291821ED003784F3 /* SummaryPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3846FBFC291821ED003784F3 /* SummaryPopupViewController.swift */; };
 		3851FC032912B3FD00CF3E89 /* MyNewsDrawerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3851FC022912B3FD00CF3E89 /* MyNewsDrawerCollectionViewCell.swift */; };
 		3851FC062912E5B400CF3E89 /* LeftAlignCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3851FC052912E5B400CF3E89 /* LeftAlignCollectionViewFlowLayout.swift */; };
 		B532C42C290AAA0F001F672B /* NextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532C42B290AAA0F001F672B /* NextButton.swift */; };
@@ -49,11 +50,6 @@
 		B5FAC8E5290786B800537F58 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8E4290786B800537F58 /* UILabel+Extension.swift */; };
 		B5FAC8E9290792C500537F58 /* QuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8E8290792C500537F58 /* QuestionView.swift */; };
 		B5FAC8EB2907BA6000537F58 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8EA2907BA6000537F58 /* UIFont+Extension.swift */; };
-		CD3A48D9290A6687002D7C15 /* SideTabbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3A48D8290A6687002D7C15 /* SideTabbarView.swift */; };
-		CD3A48DB290A66EF002D7C15 /* SideTabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3A48DA290A66EF002D7C15 /* SideTabbarViewController.swift */; };
-		CDE23AA2290ABC5000EEB824 /* InsideTabbarItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA1290ABC5000EEB824 /* InsideTabbarItemsView.swift */; };
-		CDE23AA4290ABCAE00EEB824 /* TabbarButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA3290ABCAE00EEB824 /* TabbarButtonView.swift */; };
-		CDE23AA7290ABE2200EEB824 /* SwiftUI+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA6290ABE2200EEB824 /* SwiftUI+Extension.swift */; };
 		B5FAC8ED2907D18800537F58 /* TitleInferringViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8EC2907D18800537F58 /* TitleInferringViewController.swift */; };
 		B5FAC8EF2907D2A300537F58 /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8EE2907D2A300537F58 /* BackButton.swift */; };
 		B5FAC8F12907D8C000537F58 /* BlurredLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8F02907D8C000537F58 /* BlurredLabel.swift */; };
@@ -62,6 +58,11 @@
 		B5FAC8F72909471000537F58 /* GuidingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8F62909471000537F58 /* GuidingView.swift */; };
 		B5FAC8F92909FD0300537F58 /* FiveWsAndOneHViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8F82909FD0300537F58 /* FiveWsAndOneHViewController.swift */; };
 		B5FAC8FB290A19F800537F58 /* QuestionTitleStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8FA290A19F800537F58 /* QuestionTitleStackView.swift */; };
+		CD3A48D9290A6687002D7C15 /* SideTabbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3A48D8290A6687002D7C15 /* SideTabbarView.swift */; };
+		CD3A48DB290A66EF002D7C15 /* SideTabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3A48DA290A66EF002D7C15 /* SideTabbarViewController.swift */; };
+		CDE23AA2290ABC5000EEB824 /* InsideTabbarItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA1290ABC5000EEB824 /* InsideTabbarItemsView.swift */; };
+		CDE23AA4290ABCAE00EEB824 /* TabbarButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA3290ABCAE00EEB824 /* TabbarButtonView.swift */; };
+		CDE23AA7290ABE2200EEB824 /* SwiftUI+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE23AA6290ABE2200EEB824 /* SwiftUI+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,13 +87,14 @@
 		381AB41C290A9EFE00620635 /* MainTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTitleView.swift; sourceTree = "<group>"; };
 		381AB421290AB6AD00620635 /* News.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = News.swift; sourceTree = "<group>"; };
 		381AB424290AB99900620635 /* YomojomoNewsTitleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YomojomoNewsTitleCollectionViewCell.swift; sourceTree = "<group>"; };
+		381AB428290AE18D00620635 /* EmptySpaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySpaceCollectionViewCell.swift; sourceTree = "<group>"; };
+		381AB42E290FB5EE00620635 /* NewsSortingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsSortingManager.swift; sourceTree = "<group>"; };
 		381AB435290FC96900620635 /* GotoYomojomoNewsEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotoYomojomoNewsEmptyView.swift; sourceTree = "<group>"; };
 		381AB44729116D0D00620635 /* GotoSomewhereButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotoSomewhereButton.swift; sourceTree = "<group>"; };
 		381AB4492911726B00620635 /* mp4TempFile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = mp4TempFile.json; sourceTree = "<group>"; };
+		3846FBFC291821ED003784F3 /* SummaryPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryPopupViewController.swift; sourceTree = "<group>"; };
 		3851FC022912B3FD00CF3E89 /* MyNewsDrawerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsDrawerCollectionViewCell.swift; sourceTree = "<group>"; };
 		3851FC052912E5B400CF3E89 /* LeftAlignCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
-		381AB428290AE18D00620635 /* EmptySpaceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySpaceCollectionViewCell.swift; sourceTree = "<group>"; };
-		381AB42E290FB5EE00620635 /* NewsSortingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsSortingManager.swift; sourceTree = "<group>"; };
 		B532C42B290AAA0F001F672B /* NextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextButton.swift; sourceTree = "<group>"; };
 		B55BCED628FC4C6000AF7E45 /* EarthValley80.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EarthValley80.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55BCED928FC4C6000AF7E45 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -127,11 +129,6 @@
 		B5FAC8E4290786B800537F58 /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		B5FAC8E8290792C500537F58 /* QuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionView.swift; sourceTree = "<group>"; };
 		B5FAC8EA2907BA6000537F58 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
-		CD3A48D8290A6687002D7C15 /* SideTabbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabbarView.swift; sourceTree = "<group>"; };
-		CD3A48DA290A66EF002D7C15 /* SideTabbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabbarViewController.swift; sourceTree = "<group>"; };
-		CDE23AA1290ABC5000EEB824 /* InsideTabbarItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsideTabbarItemsView.swift; sourceTree = "<group>"; };
-		CDE23AA3290ABCAE00EEB824 /* TabbarButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarButtonView.swift; sourceTree = "<group>"; };
-		CDE23AA6290ABE2200EEB824 /* SwiftUI+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extension.swift"; sourceTree = "<group>"; };
 		B5FAC8EC2907D18800537F58 /* TitleInferringViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleInferringViewController.swift; sourceTree = "<group>"; };
 		B5FAC8EE2907D2A300537F58 /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		B5FAC8F02907D8C000537F58 /* BlurredLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredLabel.swift; sourceTree = "<group>"; };
@@ -140,6 +137,11 @@
 		B5FAC8F62909471000537F58 /* GuidingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuidingView.swift; sourceTree = "<group>"; };
 		B5FAC8F82909FD0300537F58 /* FiveWsAndOneHViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiveWsAndOneHViewController.swift; sourceTree = "<group>"; };
 		B5FAC8FA290A19F800537F58 /* QuestionTitleStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionTitleStackView.swift; sourceTree = "<group>"; };
+		CD3A48D8290A6687002D7C15 /* SideTabbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabbarView.swift; sourceTree = "<group>"; };
+		CD3A48DA290A66EF002D7C15 /* SideTabbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabbarViewController.swift; sourceTree = "<group>"; };
+		CDE23AA1290ABC5000EEB824 /* InsideTabbarItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsideTabbarItemsView.swift; sourceTree = "<group>"; };
+		CDE23AA3290ABCAE00EEB824 /* TabbarButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarButtonView.swift; sourceTree = "<group>"; };
+		CDE23AA6290ABE2200EEB824 /* SwiftUI+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,12 +205,28 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		381AB42D290FB5CB00620635 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				381AB42E290FB5EE00620635 /* NewsSortingManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		381AB434290FC8E000620635 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
 				3851FC022912B3FD00CF3E89 /* MyNewsDrawerCollectionViewCell.swift */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		3846FBFB2918101E003784F3 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				3846FBFC291821ED003784F3 /* SummaryPopupViewController.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		3851FC042912E58300CF3E89 /* Helper */ = {
@@ -225,14 +243,6 @@
 				381AB4492911726B00620635 /* mp4TempFile.json */,
 			);
 			path = Lottie;
-			sourceTree = "<group>";
-		};
-		381AB42D290FB5CB00620635 /* Manager */ = {
-			isa = PBXGroup;
-			children = (
-				381AB42E290FB5EE00620635 /* NewsSortingManager.swift */,
-			);
-			path = Manager;
 			sourceTree = "<group>";
 		};
 		B55BCECD28FC4C5F00AF7E45 = {
@@ -286,7 +296,6 @@
 			isa = PBXGroup;
 			children = (
 				CD3A48D7290A6654002D7C15 /* SideTabbar */,
-				B5BE345628FD96CA00D09BEE /* NewsFeed */,
 				B5BE345628FD96CA00D09BEE /* YomojomoNews */,
 				B5BE345528FD96C700D09BEE /* News */,
 				B5BE345428FD96C100D09BEE /* MyNews */,
@@ -312,6 +321,7 @@
 		B5BE345428FD96C100D09BEE /* MyNews */ = {
 			isa = PBXGroup;
 			children = (
+				3846FBFB2918101E003784F3 /* Components */,
 				3851FC042912E58300CF3E89 /* Helper */,
 				381AB434290FC8E000620635 /* Cells */,
 				B5BE345D28FD982700D09BEE /* MyNewsDrawerViewController.swift */,
@@ -633,6 +643,7 @@
 				B5FAC8F12907D8C000537F58 /* BlurredLabel.swift in Sources */,
 				B5BE346E28FD9BB100D09BEE /* UITableView+Extension.swift in Sources */,
 				B5BE347B28FD9E5500D09BEE /* UIViewController+Alert.swift in Sources */,
+				3846FBFD291821ED003784F3 /* SummaryPopupViewController.swift in Sources */,
 				CDE23AA2290ABC5000EEB824 /* InsideTabbarItemsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -14,6 +14,9 @@ enum StringLiteral {
     static let readingNewsCaptionTitle = "기사읽기"
     static let inferringNewsCaptionTitle = "유추하기"
     static let answerWhoCaptionTitle = "대답하기 | 누가"
+    static let newstitleCaptionTitle = "기사제목"
+    static let myPredictionCaptionTitle = "나의 유추"
+    static let mySummaryCaptionTitle = "나의 요약"
     
     // MARK: - title
     

--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -14,9 +14,6 @@ enum StringLiteral {
     static let readingNewsCaptionTitle = "기사읽기"
     static let inferringNewsCaptionTitle = "유추하기"
     static let answerWhoCaptionTitle = "대답하기 | 누가"
-    static let newstitleCaptionTitle = "기사제목"
-    static let myPredictionCaptionTitle = "나의 유추"
-    static let mySummaryCaptionTitle = "나의 요약"
     
     // MARK: - title
     
@@ -24,6 +21,10 @@ enum StringLiteral {
     static let answerWhoTitle = "이 기사의 주인공은 누구인가요?"    
     static let yomojomoNewsTitle = "한 주의 요모조모 뉴스"
     static let myNewsDrawerTitle = "나의 뉴스 서랍"
+    static let popUpNewsTitle = "기사제목"
+    static let popUpMyPredictionTitle = "나의 유추"
+    static let popUpMySummaryTitle = "나의 요약"
+
 
     // MARK: - title description
 

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -33,7 +33,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let newstitleCaptionLabel: UILabel = {
         let label = UILabel()
-        label.text = StringLiteral.newstitleCaptionTitle
+        label.text = StringLiteral.popUpNewsTitle
         label.font = .font(.bold, ofSize: Size.newstitleCaptionFontSize)
         label.textColor = .evyGray1
         return label
@@ -56,7 +56,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let myPredictionCaptionLabel: UILabel = {
         let label = UILabel()
-        label.text = StringLiteral.myPredictionCaptionTitle
+        label.text = StringLiteral.popUpMyPredictionTitle
         label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label
@@ -79,7 +79,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let mySummaryCaptionLabel: UILabel = {
         let label = UILabel()
-        label.text = StringLiteral.mySummaryCaptionTitle
+        label.text = StringLiteral.popUpMySummaryTitle
         label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -90,4 +90,29 @@ final class SummaryPopupViewController: UIViewController {
         self.setupLayout()
     }
 
+    // MARK: - func
+
+    private func setupLayout() {
+        self.view.addSubview(self.sheetStackView)
+        self.sheetStackView.constraint(top: self.view.topAnchor,
+                                       leading: self.view.leadingAnchor,
+                                       trailing: self.view.trailingAnchor,
+                                       padding: UIEdgeInsets(top: 40, left: 40, bottom: 0, right: 40))
+
+        self.sheetStackView.addArrangedSubview(self.newsTitleStackView)
+        self.sheetStackView.addArrangedSubview(self.myPredictionStackView)
+        self.sheetStackView.addArrangedSubview(self.mySummaryStackView)
+
+        self.newsTitleStackView.addArrangedSubview(self.newstitleCaptionLabel)
+        self.newsTitleStackView.addArrangedSubview(self.newsTitleLabel)
+
+        self.myPredictionStackView.addArrangedSubview(self.myPredictionCaptionLabel)
+        self.myPredictionStackView.addArrangedSubview(self.myPredictionLabel)
+
+        self.mySummaryStackView.addArrangedSubview(self.mySummaryCaptionLabel)
+        self.mySummaryStackView.addArrangedSubview(self.mySummaryLabel)
+
+        self.sheetStackView.setCustomSpacing(53, after: self.newsTitleStackView)
+        self.sheetStackView.setCustomSpacing(75, after: self.myPredictionStackView)
+    }
 }

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -24,6 +24,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let newstitleCaptionLabel: UILabel = {
         let label = UILabel()
+        label.text = StringLiteral.newstitleCaptionTitle
         label.font = .font(.bold, ofSize: 12)
         label.textColor = .evyGray1
         return label
@@ -45,6 +46,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let myPredictionCaptionLabel: UILabel = {
         let label = UILabel()
+        label.text = StringLiteral.myPredictionCaptionTitle
         label.font = .font(.bold, ofSize: 20)
         label.textColor = .evyGray1
         return label
@@ -66,6 +68,7 @@ final class SummaryPopupViewController: UIViewController {
     }()
     private let mySummaryCaptionLabel: UILabel = {
         let label = UILabel()
+        label.text = StringLiteral.mySummaryCaptionTitle
         label.font = .font(.bold, ofSize: 20)
         label.textColor = .evyGray1
         return label
@@ -84,6 +87,7 @@ final class SummaryPopupViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.setupLayout()
     }
 
 }

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -1,0 +1,89 @@
+//
+//  SummaryPopupViewController.swift
+//  EarthValley80
+//
+//  Created by LeeJiSoo on 2022/11/07.
+//
+
+import UIKit
+
+final class SummaryPopupViewController: UIViewController {
+
+    // MARK: - property
+
+    private let sheetStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
+    }()
+    private let newsTitleStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        return stackView
+    }()
+    private let newstitleCaptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .font(.bold, ofSize: 12)
+        label.textColor = .evyGray1
+        return label
+    }()
+    private let newsTitleLabel: UILabel = {
+        let label = UILabel()
+        // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
+        label.text = "인류보다 로봇 진화 속도가 더 빠르대요, 청소로봇은 '루시'…생각하는 로봇 등장"
+        label.textColor = .evyBlack2
+        label.font = .font(.bold, ofSize: 20)
+        label.numberOfLines = 0
+        return label
+    }()
+    private let myPredictionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        return stackView
+    }()
+    private let myPredictionCaptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .font(.bold, ofSize: 20)
+        label.textColor = .evyGray1
+        return label
+    }()
+    private let myPredictionLabel: UILabel = {
+        let label = UILabel()
+        // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
+        label.text = "새로운 로봇"
+        label.textColor = .evyBlack1
+        label.font = .font(.bold, ofSize: 40)
+        label.numberOfLines = 0
+        return label
+    }()
+    private let mySummaryStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        return stackView
+    }()
+    private let mySummaryCaptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .font(.bold, ofSize: 20)
+        label.textColor = .evyGray1
+        return label
+    }()
+    private let mySummaryLabel: UILabel = {
+        let label = UILabel()
+        // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
+        label.text = "타다 앱서비스가 2019년 10월에 법원에서 재판을 했다. 치열하게 3년동안 싸웠는데 무면허 택시일 수도 있어서 그랬다."
+        label.textColor = .evyBlack1
+        label.font = .font(.bold, ofSize: 40)
+        label.numberOfLines = 0
+        return label
+    }()
+
+    // MARK: - life cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -31,14 +31,14 @@ final class SummaryPopupViewController: UIViewController {
         stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
-    private let newstitleCaptionLabel: UILabel = {
+    private let newsTitleLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.popUpNewsTitle
         label.font = .font(.bold, ofSize: Size.newstitleCaptionFontSize)
         label.textColor = .evyGray1
         return label
     }()
-    private let newsTitleLabel: UILabel = {
+    private let newsTitleContentLabel: UILabel = {
         let label = UILabel()
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "인류보다 로봇 진화 속도가 더 빠르대요, 청소로봇은 '루시'…생각하는 로봇 등장"
@@ -54,14 +54,14 @@ final class SummaryPopupViewController: UIViewController {
         stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
-    private let myPredictionCaptionLabel: UILabel = {
+    private let myPredictionTitleLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.popUpMyPredictionTitle
         label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label
     }()
-    private let myPredictionLabel: UILabel = {
+    private let myPredictionContentLabel: UILabel = {
         let label = UILabel()
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "새로운 로봇"
@@ -77,14 +77,14 @@ final class SummaryPopupViewController: UIViewController {
         stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
-    private let mySummaryCaptionLabel: UILabel = {
+    private let mySummaryTitleLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.popUpMySummaryTitle
         label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label
     }()
-    private let mySummaryLabel: UILabel = {
+    private let mySummaryContentLabel: UILabel = {
         let label = UILabel()
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "타다 앱서비스가 2019년 10월에 법원에서 재판을 했다. 치열하게 3년동안 싸웠는데 무면허 택시일 수도 있어서 그랬다."
@@ -118,14 +118,14 @@ final class SummaryPopupViewController: UIViewController {
         self.sheetStackView.addArrangedSubview(self.myPredictionStackView)
         self.sheetStackView.addArrangedSubview(self.mySummaryStackView)
 
-        self.newsTitleStackView.addArrangedSubview(self.newstitleCaptionLabel)
         self.newsTitleStackView.addArrangedSubview(self.newsTitleLabel)
+        self.newsTitleStackView.addArrangedSubview(self.newsTitleContentLabel)
 
-        self.myPredictionStackView.addArrangedSubview(self.myPredictionCaptionLabel)
-        self.myPredictionStackView.addArrangedSubview(self.myPredictionLabel)
+        self.myPredictionStackView.addArrangedSubview(self.myPredictionTitleLabel)
+        self.myPredictionStackView.addArrangedSubview(self.myPredictionContentLabel)
 
-        self.mySummaryStackView.addArrangedSubview(self.mySummaryCaptionLabel)
-        self.mySummaryStackView.addArrangedSubview(self.mySummaryLabel)
+        self.mySummaryStackView.addArrangedSubview(self.mySummaryTitleLabel)
+        self.mySummaryStackView.addArrangedSubview(self.mySummaryContentLabel)
 
         self.sheetStackView.setCustomSpacing(53, after: self.newsTitleStackView)
         self.sheetStackView.setCustomSpacing(75, after: self.myPredictionStackView)

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -45,6 +45,7 @@ final class SummaryPopupViewController: UIViewController {
         label.textColor = .evyBlack2
         label.font = .font(.bold, ofSize: Size.newsTitleFontSize)
         label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
         return label
     }()
     private let myPredictionStackView: UIStackView = {
@@ -67,6 +68,7 @@ final class SummaryPopupViewController: UIViewController {
         label.textColor = .evyBlack1
         label.font = .font(.bold, ofSize: Size.contentsFontSize)
         label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
         return label
     }()
     private let mySummaryStackView: UIStackView = {
@@ -89,6 +91,7 @@ final class SummaryPopupViewController: UIViewController {
         label.textColor = .evyBlack1
         label.font = .font(.bold, ofSize: Size.contentsFontSize)
         label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
         return label
     }()
 

--- a/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/MyNews/Components/SummaryPopupViewController.swift
@@ -9,6 +9,15 @@ import UIKit
 
 final class SummaryPopupViewController: UIViewController {
 
+    private enum Size {
+        static let stackViewSpacing: CGFloat = 10.0
+        static let newstitleCaptionFontSize: CGFloat = 12.0
+        static let newsTitleFontSize: CGFloat = 20.0
+        static let captionFontSize: CGFloat = 20.0
+        static let contentsFontSize: CGFloat = 40.0
+        static let sheetStackViewPadding: CGFloat = 40.0
+    }
+
     // MARK: - property
 
     private let sheetStackView: UIStackView = {
@@ -19,13 +28,13 @@ final class SummaryPopupViewController: UIViewController {
     private let newsTitleStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 10
+        stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
     private let newstitleCaptionLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.newstitleCaptionTitle
-        label.font = .font(.bold, ofSize: 12)
+        label.font = .font(.bold, ofSize: Size.newstitleCaptionFontSize)
         label.textColor = .evyGray1
         return label
     }()
@@ -34,20 +43,20 @@ final class SummaryPopupViewController: UIViewController {
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "인류보다 로봇 진화 속도가 더 빠르대요, 청소로봇은 '루시'…생각하는 로봇 등장"
         label.textColor = .evyBlack2
-        label.font = .font(.bold, ofSize: 20)
+        label.font = .font(.bold, ofSize: Size.newsTitleFontSize)
         label.numberOfLines = 0
         return label
     }()
     private let myPredictionStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 10
+        stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
     private let myPredictionCaptionLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.myPredictionCaptionTitle
-        label.font = .font(.bold, ofSize: 20)
+        label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label
     }()
@@ -56,20 +65,20 @@ final class SummaryPopupViewController: UIViewController {
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "새로운 로봇"
         label.textColor = .evyBlack1
-        label.font = .font(.bold, ofSize: 40)
+        label.font = .font(.bold, ofSize: Size.contentsFontSize)
         label.numberOfLines = 0
         return label
     }()
     private let mySummaryStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 10
+        stackView.spacing = Size.stackViewSpacing
         return stackView
     }()
     private let mySummaryCaptionLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiteral.mySummaryCaptionTitle
-        label.font = .font(.bold, ofSize: 20)
+        label.font = .font(.bold, ofSize: Size.captionFontSize)
         label.textColor = .evyGray1
         return label
     }()
@@ -78,7 +87,7 @@ final class SummaryPopupViewController: UIViewController {
         // TODO: - 더미데이터입니다. 나중에 지우겠습니다.
         label.text = "타다 앱서비스가 2019년 10월에 법원에서 재판을 했다. 치열하게 3년동안 싸웠는데 무면허 택시일 수도 있어서 그랬다."
         label.textColor = .evyBlack1
-        label.font = .font(.bold, ofSize: 40)
+        label.font = .font(.bold, ofSize: Size.contentsFontSize)
         label.numberOfLines = 0
         return label
     }()
@@ -97,7 +106,10 @@ final class SummaryPopupViewController: UIViewController {
         self.sheetStackView.constraint(top: self.view.topAnchor,
                                        leading: self.view.leadingAnchor,
                                        trailing: self.view.trailingAnchor,
-                                       padding: UIEdgeInsets(top: 40, left: 40, bottom: 0, right: 40))
+                                       padding: UIEdgeInsets(top: Size.sheetStackViewPadding,
+                                                             left: Size.sheetStackViewPadding,
+                                                             bottom: 0,
+                                                             right: Size.sheetStackViewPadding))
 
         self.sheetStackView.addArrangedSubview(self.newsTitleStackView)
         self.sheetStackView.addArrangedSubview(self.myPredictionStackView)


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #65 

## ⚫️  변경사항
<!-- 의존성 목록 -->
- 없음! 😜

## ⚫️  새로운 기능
<!-- 기능 목록 -->

### ➰ SummaryPopupViewController
특별한건 없습니다!. popup view 내부에 label로만 이루어져있기 때문에 딱히 새로운 기능은 없고, 추후 해당 뷰를 collectionview cell이 터치되었을때 modal로 뜨게 만들어 줄것입니다. (해당 pr은 껍데기만 만드는 pr입니다!)

디자이너님이, ipad page sheet로 만들어달라고 하셨습니다.
| 디자이너에게 받은 화면|
|--|
|<img width="369" alt="image" src="https://user-images.githubusercontent.com/96969693/200187481-0d55ded1-bbac-4719-80f0-95f109c1f288.png">|

### ⁉️ page sheet가 뭐지? 
네,,, HIG를 .. 제대로 공부하지 않은게 티가 났네요,,, HIG공부하겠습니다 ㅜㅜㅜ 
찾아보니까, page sheet는 일반적으로 아이폰에서 사용되는 모달창입니다. 모달창의 모양이 ipad에서는 흔히말하는 팝업창 같이 생겼군요!
모달하면 가장 먼저 떠오르는 기본 mail앱 예시를 아래 넣어두겠습니다. _**(추후 이것과 관련해서 discussion을 올려볼게요! 오호호호옿호호 HIG공부도하고 일석이조!)**_

| 아이폰에서의 modal창 | 아이패드에서의 modal 창 |
|--|--|
|<img width="250" alt="image" src="https://user-images.githubusercontent.com/96969693/200187791-b3859527-87cf-4021-9a4a-315a70f5ca4c.png">|<img width="550" alt="image" src="https://user-images.githubusercontent.com/96969693/200187773-56120560-fef9-43b1-848e-0245ff878ae0.png">|

(아이쿠, 다크모드라 잘 안보이네용,, )
위 처럼, 팝업처럼 뜨는 page sheet를 사용하고싶다는 것이 디자이너님의 의도입니당! 

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

- 일단 full screen 기준으로 뜨게 껍데기만 만들어놓은 상태입니다.

| 구현화면 | 
|--| 
|<img width="727" alt="image" src="https://user-images.githubusercontent.com/96969693/200187879-8bc99c81-3d10-4cab-bfea-38a70e0b20d1.png">|



### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
