### PR TITLE
[FEAT] 요약하기 뷰로 이동 및 내부에서 텍스트 작성했을 때 다음으로 버튼 활성화되도록 구현했습니다.

### DIFF
--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -30,7 +30,8 @@ enum StringLiteral {
     // MARK: - title
     
     static let inferringNewsTitle = "이 기사는 어떤 내용의 기사일까요?"
-    static let summarizeNewsTitle = "와우! 키워드를 모두 완성시켰군요"
+    static let keywordNewsTitle = "와우! 키워드를 모두 완성시켰군요"
+    static let summarizeNewsTitle = "아래 키워드를 보며 이 기사를 요약해볼까요?"
     static let yomojomoNewsTitle = "한 주의 요모조모 뉴스"
     static let myNewsDrawerTitle = "나의 뉴스 서랍"
 
@@ -49,6 +50,7 @@ enum StringLiteral {
     static let answerWhatPlaceholder = "3가지 질문이 남아있어요"
     static let answerHowPlaceholder = "2가지 질문이 남아있어요"
     static let answerWhyPlaceholder = "마지막 질문이에요"
+    static let summarizePlaceholder = "키워드의 단어와 단어 사이를 연결하면 쉬워요"
     
     // MARK: - button
     

--- a/EarthValley80/EarthValley80/Global/Supports/Info.plist
+++ b/EarthValley80/EarthValley80/Global/Supports/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>NewsFeed</string>
+					<string>News</string>
 				</dict>
 			</array>
 		</dict>

--- a/EarthValley80/EarthValley80/Global/Supports/Info.plist
+++ b/EarthValley80/EarthValley80/Global/Supports/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>News</string>
+					<string>NewsFeed</string>
 				</dict>
 			</array>
 		</dict>

--- a/EarthValley80/EarthValley80/Screen/News/Components/QuestionView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/QuestionView.swift
@@ -48,7 +48,8 @@ final class QuestionView: UIView {
         case what = 3
         case how = 4
         case why = 5
-        case summarize = 6
+        case keyword = 6
+        case summarize = 7
         
         var previousButtonIsHidden: Bool {
             switch self {
@@ -64,7 +65,7 @@ final class QuestionView: UIView {
             case .infer,
                  .reading,
                  .who,
-                 .summarize:
+                 .keyword:
                 return true
             default:
                 return false
@@ -73,7 +74,7 @@ final class QuestionView: UIView {
         
         var keywordCollectionViewIsHidden: Bool {
             switch self {
-            case .summarize:
+            case .keyword:
                 return false
             default:
                 return true
@@ -82,7 +83,7 @@ final class QuestionView: UIView {
         
         var textViewIsHidden: Bool {
             switch self {
-            case .summarize:
+            case .keyword:
                 return true
             default:
                 return false
@@ -107,7 +108,8 @@ final class QuestionView: UIView {
                 return StringLiteral.answerWhyCaptionTitle
             case .reading:
                 return StringLiteral.answerWhoCaptionTitle
-            case .summarize:
+            case .keyword,
+                 .summarize:
                 return StringLiteral.summarizeNewsCaptionTitle
             }
         }
@@ -131,6 +133,8 @@ final class QuestionView: UIView {
             case .reading:
                 return StringLiteral.answerWhoPlaceholder
             case .summarize:
+                return StringLiteral.summarizePlaceholder
+            default:
                 return ""
             }
         }
@@ -211,7 +215,7 @@ final class QuestionView: UIView {
     
     private(set) var step: Step = .infer {
         didSet {
-            if self.step == .summarize {
+            if self.step == .keyword {
                 self.keywordCollectionView.reloadData()
             }
         }
@@ -330,7 +334,7 @@ final class QuestionView: UIView {
         
         self.contentTextView.resignFirstResponder()
         
-        if step != .summarize {
+        if step != .keyword {
             self.updateTextViewContentToAnswer(with: step)
         }
     }
@@ -368,7 +372,7 @@ extension QuestionView: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
         guard
             self.textMode != .beforeWriting,
-            self.step != .summarize
+            self.step != .keyword
         else { return }
         
         self.nextButton.configType = textView.hasText ? .next : .disabled
@@ -378,12 +382,12 @@ extension QuestionView: UITextViewDelegate {
 // MARK: - UICollectionViewDataSource
 extension QuestionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard step == .summarize else { return 0 }
+        guard step == .keyword else { return 0 }
         return self.questionTitleStackView.answers.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard step == .summarize else { return UICollectionViewCell() }
+        guard step == .keyword else { return UICollectionViewCell() }
         let cell: AnswerCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
         let index = indexPath.item
         

--- a/EarthValley80/EarthValley80/Screen/News/Components/QuestionView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/QuestionView.swift
@@ -90,6 +90,17 @@ final class QuestionView: UIView {
             }
         }
         
+        var nextTitleConfigType: NextButton.ConfigType {
+            switch self {
+            case .summarize:
+                return .complete
+            case .keyword:
+                return .summarize
+            default:
+                return .next
+            }
+        }
+        
         var captionText: String {
             switch self {
             case .infer:
@@ -373,9 +384,14 @@ extension QuestionView: UITextViewDelegate {
         guard
             self.textMode != .beforeWriting,
             self.step != .keyword
-        else { return }
+        else {
+            if self.step == .keyword {
+                self.nextButton.configType = self.step.nextTitleConfigType
+            }
+            return
+        }
         
-        self.nextButton.configType = textView.hasText ? .next : .disabled
+        self.nextButton.configType = textView.hasText ? self.step.nextTitleConfigType : .disabled
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/News/FiveWsAndOneHViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/FiveWsAndOneHViewController.swift
@@ -41,7 +41,9 @@ final class FiveWsAndOneHViewController: UIViewController {
             guard view.step.rawValue < QuestionView.Step.allCases.count else { return }
             guard let nextStep = QuestionView.Step(rawValue: view.step.rawValue + 1) else { return }
             
-            view.updateAnswer(at: view.step.rawValue, to: view.contentTextView.text)
+            if view.step.rawValue >= 0 && view.step.rawValue < 6 {
+                view.updateAnswer(at: view.step.rawValue, to: view.contentTextView.text)
+            }
             view.updateConfiguration(with: nextStep)
         }
         view.setupNextAction(action)
@@ -53,6 +55,7 @@ final class FiveWsAndOneHViewController: UIViewController {
             "무엇 때문에 일어난 일인가요?",
             "어떻게 일어난 일인가요?",
             "왜 이런일이 일어났나요?",
+            StringLiteral.keywordNewsTitle,
             StringLiteral.summarizeNewsTitle
         ]
         return view


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #83 

## ⚫️  변경사항
<!-- 의존성 목록 -->

### ☑️ 원래 summarize를 keyword로 네이밍 변경

- 요약을 위한 키워드가 있는 뷰를 summarize로 했더니 요약하기 뷰의 case 이름이 애매해져서 키워드가 있는 뷰 네이밍을 keyword로 변경했습니다.

## ⚫️  새로운 기능
<!-- 기능 목록 -->

### ➰ summarize type일 때의 configuartion 설정 부분들 추가

summarize 일 때의 title, caption, placeholder를 추가했습니다. 전과 추가하는 방식이 동일하고 enum에만 넣으면 알아서 설정이 되기 때문에 값을 넣어주는 일만 진행했습니다. 
<img width="416" alt="스크린샷 2022-11-09 오후 10 22 48" src="https://user-images.githubusercontent.com/55099365/200841432-9b2d230b-6350-483a-99c1-8adbc637d352.png">

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

https://user-images.githubusercontent.com/55099365/200841605-3e43509e-245d-40f7-8334-434a680e2620.mov

### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
