### PR TITLE
[ADD] 요약 하기 뷰(SummaryViewController)의 레이아웃을 구성했습니다.

### DIFF
--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		B55BCEFB28FC4C6100AF7E45 /* EarthValley80UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEFA28FC4C6100AF7E45 /* EarthValley80UITests.swift */; };
 		B55BCEFD28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEFC28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift */; };
 		B589F370292718BC008468A8 /* SummaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B589F36F292718BC008468A8 /* SummaryViewController.swift */; };
+		B589F3722927232A008468A8 /* SummaryTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B589F3712927232A008468A8 /* SummaryTextView.swift */; };
 		B5BE345C28FD981C00D09BEE /* MyNews.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5BE345B28FD981C00D09BEE /* MyNews.storyboard */; };
 		B5BE345E28FD982700D09BEE /* MyNewsDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE345D28FD982700D09BEE /* MyNewsDrawerViewController.swift */; };
 		B5BE346028FD984C00D09BEE /* News.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5BE345F28FD984C00D09BEE /* News.storyboard */; };
@@ -133,6 +134,7 @@
 		B55BCEFA28FC4C6100AF7E45 /* EarthValley80UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthValley80UITests.swift; sourceTree = "<group>"; };
 		B55BCEFC28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthValley80UITestsLaunchTests.swift; sourceTree = "<group>"; };
 		B589F36F292718BC008468A8 /* SummaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewController.swift; sourceTree = "<group>"; };
+		B589F3712927232A008468A8 /* SummaryTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTextView.swift; sourceTree = "<group>"; };
 		B5BE345B28FD981C00D09BEE /* MyNews.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MyNews.storyboard; sourceTree = "<group>"; };
 		B5BE345D28FD982700D09BEE /* MyNewsDrawerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsDrawerViewController.swift; sourceTree = "<group>"; };
 		B5BE345F28FD984C00D09BEE /* News.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = News.storyboard; sourceTree = "<group>"; };
@@ -470,6 +472,7 @@
 				B50E7A49292604DD009D8410 /* CapsuleFormTitleView.swift */,
 				B50E7A4D29260C19009D8410 /* ReactionButton.swift */,
 				B50E7A5529264E59009D8410 /* ReactionEmojiView.swift */,
+				B589F3712927232A008468A8 /* SummaryTextView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -676,6 +679,7 @@
 				B5205BDA2914E8B200821C8B /* UserDefaultHandler.swift in Sources */,
 				381AB419290A9AE500620635 /* Date+Extension.swift in Sources */,
 				381AB44829116D0D00620635 /* GotoSomewhereButton.swift in Sources */,
+				B589F3722927232A008468A8 /* SummaryTextView.swift in Sources */,
 				B5FAC8FB290A19F800537F58 /* QuestionTitleStackView.swift in Sources */,
 				B5FAC8F92909FD0300537F58 /* FiveWsAndOneHViewController.swift in Sources */,
 				CDE23AA7290ABE2200EEB824 /* SwiftUI+Extension.swift in Sources */,

--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		B55BCEF128FC4C6100AF7E45 /* EarthValley80Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEF028FC4C6100AF7E45 /* EarthValley80Tests.swift */; };
 		B55BCEFB28FC4C6100AF7E45 /* EarthValley80UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEFA28FC4C6100AF7E45 /* EarthValley80UITests.swift */; };
 		B55BCEFD28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BCEFC28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift */; };
+		B589F370292718BC008468A8 /* SummaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B589F36F292718BC008468A8 /* SummaryViewController.swift */; };
 		B5BE345C28FD981C00D09BEE /* MyNews.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5BE345B28FD981C00D09BEE /* MyNews.storyboard */; };
 		B5BE345E28FD982700D09BEE /* MyNewsDrawerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE345D28FD982700D09BEE /* MyNewsDrawerViewController.swift */; };
 		B5BE346028FD984C00D09BEE /* News.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5BE345F28FD984C00D09BEE /* News.storyboard */; };
@@ -131,6 +132,7 @@
 		B55BCEF628FC4C6100AF7E45 /* EarthValley80UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EarthValley80UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55BCEFA28FC4C6100AF7E45 /* EarthValley80UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthValley80UITests.swift; sourceTree = "<group>"; };
 		B55BCEFC28FC4C6100AF7E45 /* EarthValley80UITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarthValley80UITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B589F36F292718BC008468A8 /* SummaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewController.swift; sourceTree = "<group>"; };
 		B5BE345B28FD981C00D09BEE /* MyNews.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MyNews.storyboard; sourceTree = "<group>"; };
 		B5BE345D28FD982700D09BEE /* MyNewsDrawerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsDrawerViewController.swift; sourceTree = "<group>"; };
 		B5BE345F28FD984C00D09BEE /* News.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = News.storyboard; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 				B5FAC8F429093CB500537F58 /* NewsGuideViewController.swift */,
 				B5FAC8F82909FD0300537F58 /* FiveWsAndOneHViewController.swift */,
 				B50E7A462925C072009D8410 /* ReactionViewController.swift */,
+				B589F36F292718BC008468A8 /* SummaryViewController.swift */,
 			);
 			path = News;
 			sourceTree = "<group>";
@@ -655,6 +658,7 @@
 				CD3A48D9290A6687002D7C15 /* SideTabbarView.swift in Sources */,
 				CD3A48DB290A66EF002D7C15 /* SideTabbarViewController.swift in Sources */,
 				B532C42C290AAA0F001F672B /* NextButton.swift in Sources */,
+				B589F370292718BC008468A8 /* SummaryViewController.swift in Sources */,
 				B5BE347428FD9CD200D09BEE /* UIView+Extension.swift in Sources */,
 				B5205BD82914E86900821C8B /* UserDefaultStorage.swift in Sources */,
 				B5BE347028FD9C2C00D09BEE /* UICollectionView+Extension.swift in Sources */,

--- a/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UIViewController {
     func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
+        let tap = UITapGestureRecognizer(target: self, action: #selector(self.endEditingView))
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }

--- a/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
@@ -9,12 +9,12 @@ import UIKit
 
 extension UIViewController {
     func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(self.endEditingView))
+        let tap = UITapGestureRecognizer(target: self, action: #selector(self.dismissKeyboard))
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
     
-    @objc func endEditingView() {
+    @objc func dismissKeyboard() {
         view.endEditing(true)
     }
 }

--- a/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UIViewController+Extension.swift
@@ -9,12 +9,12 @@ import UIKit
 
 extension UIViewController {
     func hideKeyboardWhenTappedAround() {
-        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        let tap = UITapGestureRecognizer(target: self, action: #selector(endEditingView))
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
     
-    @objc func dismissKeyboard() {
+    @objc func endEditingView() {
         view.endEditing(true)
     }
 }

--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -45,6 +45,7 @@ enum StringLiteral {
     static let reactionTitle = "짝짝짝 다 읽었군요! 이 기사, 어땠나요?"
     static let selectedReactionTitle = "이 기사에 대한 중심문장을 찾으러 가볼까요?"
     static let guidingTitle = "화면을 터치하면 뉴스를 읽을 수 있어요"
+    static let summaryTitle = "기사를 요약하거나 생각을 자유롭게 풀어보세요"
 
     // MARK: - title description
 

--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -64,7 +64,7 @@ enum StringLiteral {
     static let answerWhatPlaceholder = "3가지 질문이 남아있어요"
     static let answerHowPlaceholder = "2가지 질문이 남아있어요"
     static let answerWhyPlaceholder = "마지막 질문이에요"
-    static let summarizePlaceholder = "키워드의 단어와 단어 사이를 연결하면 쉬워요"
+    static let summarizePlaceholder = "내용을 입력하세요"
     
     // MARK: - button
     

--- a/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
+++ b/EarthValley80/EarthValley80/Global/Literals/StringLiteral.swift
@@ -73,6 +73,7 @@ enum StringLiteral {
     static let completeButtonText = "완성했어요!"
     static let backButtonText = "홈으로"
     static let newsCompleteCheckButtonText = "내 피드에서 확인하기"
+    static let myMainSentenceButtonText = "내가 찾은 중심문장"
 
     // MARK: - lottie
 

--- a/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
+++ b/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         self.window?.backgroundColor = .systemBackground
-        self.window?.rootViewController = SideTabbarViewController()
+        self.window?.rootViewController = SummaryViewController()
         self.window?.makeKeyAndVisible()
     }
     

--- a/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
+++ b/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         self.window?.backgroundColor = .systemBackground
-        self.window?.rootViewController = SummaryViewController()
+        self.window?.rootViewController = SideTabbarViewController()
         self.window?.makeKeyAndVisible()
     }
     

--- a/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
@@ -23,7 +23,7 @@ final class SummaryTextView: UIView {
         var placeholder: String? {
             switch self {
             case .beforeWriting:
-                return "리뷰를 남겨주세요"
+                return StringLiteral.summarizePlaceholder
             default:
                 return nil
             }
@@ -58,6 +58,14 @@ final class SummaryTextView: UIView {
         textView.delegate = self
         return textView
     }()
+    var textMode: TextMode? {
+        willSet {
+            guard let newValue = newValue,
+                  newValue != .complete else { return }
+
+            self.updateTextViewConfiguration(with: newValue)
+        }
+    }
 
     // MARK: - init
 
@@ -86,8 +94,23 @@ final class SummaryTextView: UIView {
                                         insets: UIEdgeInsets(top: Size.textViewSpacing, left: 0, bottom: -Size.textViewSpacing, right: 0))
 
     }
+
+    private func updateTextViewConfiguration(with state: TextMode) {
+        self.contentTextView.text = state.placeholder
+        self.contentTextView.textColor = state.textColor
+    }
 }
 
 extension SummaryTextView: UITextViewDelegate {
-    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        let isBeforeWriting = self.textMode == .beforeWriting
+        if isBeforeWriting {
+            self.textMode = .write
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        let isEmpty = textView.text.isEmpty
+        self.textMode = isEmpty ? .beforeWriting : .complete
+    }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
@@ -1,0 +1,93 @@
+//
+//  SummaryTextView.swift
+//  EarthValley80
+//
+//  Created by SHIN YOON AH on 2022/11/18.
+//
+
+import UIKit
+
+final class SummaryTextView: UIView {
+
+    private enum Size {
+        static let backgroundSpacing: CGFloat = 30.0
+        static let textViewSpacing: CGFloat = 20.0
+        static let containerTopInset: CGFloat = 64 - textViewSpacing
+    }
+
+    enum TextMode {
+        case beforeWriting
+        case write
+        case complete
+
+        var placeholder: String? {
+            switch self {
+            case .beforeWriting:
+                return "리뷰를 남겨주세요"
+            default:
+                return nil
+            }
+        }
+
+        var textColor: UIColor {
+            switch self {
+            case .beforeWriting:
+                return .tertiaryLabel
+            default:
+                return .black
+            }
+        }
+    }
+
+    // MARK: - property
+
+    private let backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .evyWhite
+        view.layer.cornerRadius = 30.0
+        return view
+    }()
+    private lazy var contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.textContainer.lineBreakMode = .byCharWrapping
+        textView.setTypingAttributes(lineSpacing: 10.0)
+        textView.font = .font(.regular, ofSize: 34)
+        textView.tintColor = .evyBlack1
+        textView.backgroundColor = .clear
+        textView.textContainerInset = UIEdgeInsets(top: Size.containerTopInset, left: 40, bottom: 0, right: 72)
+        textView.delegate = self
+        return textView
+    }()
+
+    // MARK: - init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - func
+
+    private func setupLayout() {
+        self.addSubview(backgroundView)
+        self.backgroundView.constraint(top: self.topAnchor,
+                                       leading: self.leadingAnchor,
+                                       bottom: self.bottomAnchor,
+                                       trailing: self.trailingAnchor,
+                                       padding: UIEdgeInsets(top: 0, left: Size.backgroundSpacing, bottom: Size.backgroundSpacing, right: Size.backgroundSpacing))
+
+        self.backgroundView.addSubview(self.contentTextView)
+        self.contentTextView.constraint(to: self.backgroundView,
+                                        insets: UIEdgeInsets(top: Size.textViewSpacing, left: 0, bottom: -Size.textViewSpacing, right: 0))
+
+    }
+}
+
+extension SummaryTextView: UITextViewDelegate {
+    
+}

--- a/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
@@ -34,7 +34,7 @@ final class SummaryTextView: UIView {
             case .beforeWriting:
                 return .tertiaryLabel
             default:
-                return .black
+                return .evyBlack2
             }
         }
     }
@@ -52,7 +52,7 @@ final class SummaryTextView: UIView {
         textView.textContainer.lineBreakMode = .byCharWrapping
         textView.setTypingAttributes(lineSpacing: 10.0)
         textView.font = .font(.regular, ofSize: 34)
-        textView.tintColor = .evyBlack1
+        textView.tintColor = .evyBlack2
         textView.backgroundColor = .clear
         textView.textContainerInset = UIEdgeInsets(top: Size.containerTopInset, left: 40, bottom: 0, right: 72)
         textView.delegate = self

--- a/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/SummaryTextView.swift
@@ -17,7 +17,7 @@ final class SummaryTextView: UIView {
 
     enum TextMode {
         case beforeWriting
-        case write
+        case writing
         case complete
 
         var placeholder: String? {
@@ -139,7 +139,7 @@ extension SummaryTextView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         let isBeforeWriting = self.textMode == .beforeWriting
         if isBeforeWriting {
-            self.textMode = .write
+            self.textMode = .writing
         }
     }
 

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -11,6 +11,15 @@ final class SummaryViewController: UIViewController {
 
     // MARK: - property
 
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .font(.bold, ofSize: 15)
+        label.text = StringLiteral.readingNewsCaptionTitle
+        label.textColor = .evyWhite
+        return label
+    }()
+    private let backButton = BackButton()
+    private let titleView: CapsuleFormTitleView = CapsuleFormTitleView(title: StringLiteral.summaryTitle)
 
 
     // MARK: - life cycle
@@ -18,11 +27,30 @@ final class SummaryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupLayout()
+        self.configureUI()
     }
 
     // MARK: - func
 
     private func setupLayout() {
+        self.view.addSubview(self.backButton)
+        self.backButton.constraint(top: self.view.topAnchor,
+                                   leading: self.view.leadingAnchor,
+                                   padding: UIEdgeInsets(top: 26, left: 10, bottom: 0, right: 0))
 
+        self.view.addSubview(self.captionLabel)
+        self.captionLabel.constraint(top: self.view.topAnchor,
+                                     centerX: self.view.centerXAnchor,
+                                     padding: UIEdgeInsets(top: 40, left: 0, bottom: 0, right: 0))
+
+        self.view.addSubview(self.titleView)
+        self.titleView.constraint(top: self.captionLabel.bottomAnchor,
+                                  centerX: self.view.centerXAnchor,
+                                  padding: UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0))
+    }
+
+    private func configureUI() {
+        // TODO: - 컬러셋 정해지면 변경
+        self.view.backgroundColor = .black.withAlphaComponent(0.94)
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -48,7 +48,11 @@ final class SummaryViewController: UIViewController {
 
         return button
     }()
-    private let summaryTextView: SummaryTextView = SummaryTextView()
+    private let summaryTextView: SummaryTextView = {
+        let textView = SummaryTextView()
+        textView.textMode = .beforeWriting
+        return textView
+    }()
 
     // MARK: - life cycle
 
@@ -56,6 +60,7 @@ final class SummaryViewController: UIViewController {
         super.viewDidLoad()
         self.setupLayout()
         self.configureUI()
+        self.hideKeyboardWhenTappedAround()
     }
 
     // MARK: - func
@@ -92,5 +97,14 @@ final class SummaryViewController: UIViewController {
     private func configureUI() {
         // TODO: - 컬러셋 정해지면 변경
         self.view.backgroundColor = .black.withAlphaComponent(0.94)
+    }
+
+    // MARK: - selector
+
+    @objc
+    override func endEditingView() {
+        if !myMainSentenceButton.isTouchInside {
+            view.endEditing(true)
+        }
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -48,7 +48,7 @@ final class SummaryViewController: UIViewController {
 
         return button
     }()
-
+    private let summaryTextView: SummaryTextView = SummaryTextView()
 
     // MARK: - life cycle
 
@@ -80,6 +80,13 @@ final class SummaryViewController: UIViewController {
         self.myMainSentenceButton.constraint(top: self.view.topAnchor,
                                              trailing: self.view.trailingAnchor,
                                              padding: UIEdgeInsets(top: 46, left: 0, bottom: 0, right: 60))
+
+        self.view.addSubview(self.summaryTextView)
+        self.summaryTextView.constraint(top: self.myMainSentenceButton.bottomAnchor,
+                                        leading: self.view.leadingAnchor,
+                                        bottom: self.view.bottomAnchor,
+                                        trailing: self.view.trailingAnchor,
+                                        padding: UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0))
     }
 
     private func configureUI() {

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -102,7 +102,7 @@ final class SummaryViewController: UIViewController {
     // MARK: - selector
 
     @objc
-    override func endEditingView() {
+    override func dismissKeyboard() {
         if !myMainSentenceButton.isTouchInside {
             view.endEditing(true)
         }

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -1,0 +1,28 @@
+//
+//  SummaryViewController.swift
+//  EarthValley80
+//
+//  Created by SHIN YOON AH on 2022/11/18.
+//
+
+import UIKit
+
+final class SummaryViewController: UIViewController {
+
+    // MARK: - property
+
+
+
+    // MARK: - life cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setupLayout()
+    }
+
+    // MARK: - func
+
+    private func setupLayout() {
+
+    }
+}

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 
 final class SummaryViewController: UIViewController {
 
+    private enum Size {
+        static let buttonSize: CGFloat = 69.0
+    }
+
     // MARK: - property
 
     private let captionLabel: UILabel = {
@@ -20,6 +24,30 @@ final class SummaryViewController: UIViewController {
     }()
     private let backButton = BackButton()
     private let titleView: CapsuleFormTitleView = CapsuleFormTitleView(title: StringLiteral.summaryTitle)
+    private let myMainSentenceButton: UIButton = {
+        let button = UIButton()
+
+        // TODO: - 나중에 Asset 이미지 변경
+        let imageView = UIImageView(image: UIImage(systemName: "pencil.circle"))
+        button.addSubview(imageView)
+        imageView.constraint(top: button.topAnchor, centerX: button.centerXAnchor)
+        imageView.constraint(.heightAnchor, constant: Size.buttonSize)
+        imageView.constraint(.widthAnchor, constant: Size.buttonSize)
+        imageView.makeShadow(color: .evyBlack1, opacity: 0.3, offset: CGSize.zero, radius: 7)
+
+        let titleLabel = UILabel()
+        button.addSubview(titleLabel)
+        titleLabel.constraint(top: imageView.bottomAnchor,
+                              leading: button.leadingAnchor,
+                              bottom: button.bottomAnchor,
+                              trailing: button.trailingAnchor,
+                              padding: UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0))
+        titleLabel.text = StringLiteral.myMainSentenceButtonText
+        titleLabel.font = .font(.bold, ofSize: 10)
+        titleLabel.textColor = .evyWhite
+
+        return button
+    }()
 
 
     // MARK: - life cycle
@@ -47,6 +75,11 @@ final class SummaryViewController: UIViewController {
         self.titleView.constraint(top: self.captionLabel.bottomAnchor,
                                   centerX: self.view.centerXAnchor,
                                   padding: UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0))
+
+        self.view.addSubview(self.myMainSentenceButton)
+        self.myMainSentenceButton.constraint(top: self.view.topAnchor,
+                                             trailing: self.view.trailingAnchor,
+                                             padding: UIEdgeInsets(top: 46, left: 0, bottom: 0, right: 60))
     }
 
     private func configureUI() {


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #128 

## ⚫️  변경사항
<!-- 의존성 목록 -->

### ➰ dismissKeyboard 메소드 네이밍 변경

dismissKeyboard라는 네이밍이 적절하지 않은 거 같아서 `endEditingView`로 변경했습니다. 
아무곳이나 클릭하면 실행되는 hideKeyboardWhenTappedAround 메소드의 Selector로 들어가 있는 이 메소드는 아무곳이나 눌렀을 시에 실행됩니다. dismissKeyboard라고 했을 때 키보드를 dismiss하는 데에만 집중한 메소드같아서 네이밍을 endEditingView로 변경했습니다. 

이렇게 변경한 이유는 View를 Editing, 즉 TextView에 글을 쓰는 행위를 end 했을 때, 혹은 그냥 View를 Edit하는 행위를 끝냈을 때 실행되는 메소드이다. 라는 의미에서 네이밍을 변경했습니다.

dismissKeyboard 라는 네이밍은 조금 범위가 Keyboard에 한정된 느낌이더라구요.!👀
제 개인적인 의견이기 때문에 다른 분들은 어떻게 생각하시는지 알고 싶어요! 별로라면 별로라고 해주셔도 되고, 제안할만한 네이밍이 있다면 제안해주셔도 됩니다.

### ➰ endEditingView override 사용

endEditingView는 hideKeyboardWhenTappedAround의 메소드로 UIViewController+Extension에 포함되어 있어요. 해당 메소드는 override해서 재정의해 사용할 수 있습니다. 

위에서 말한 대로 해당 메소드는 아무곳이나 눌렀을 시에 실행이 되는데, `내가 찾은 중심 문장` 이라는 버튼을 눌렀을 때에도 내려가게 됩니다. 아이가 `내가 찾은 중심 문장을 글 쓰는 중간에 보고 싶어 할 거 같다는 생각` + `중심문장을 보고 바로 글을 작성할 것이다 라는 생각` 이 들어서 해당 버튼을 눌렀을 때는 Keyboard가 내려가지 않도록 로직을 짜뒀습니다.

```swift
@objc
    override func endEditingView() {
        if !myMainSentenceButton.isTouchInside {
            view.endEditing(true)
        }
    }
```

이 부분도 그냥 제 생각일 뿐이라서 다른 분들한테도 물어봐야할 거 같아요.! 어떠신가요?

<br>

## ⚫️  새로운 기능
<!-- 기능 목록 -->

### ☑️ TextView를 관리하는 enum을 추가했습니다.

#66 에서도 동일하게 사용한 적 있는 코드입니다.
TextMode라는 enum 타입을 만들어두고 3가지 case를 나눠서 진행했습니다. 

* beforeWriting : 글을 쓰기 전, 글을 쓰지 않았기 때문에 placeholder가 존재합니다.
* write : 글을 쓰고 있는 와중입니다. 따라서 textColor가 black으로 변경됩니다.
* complete : 글을 쓰는 행위를 마친 상황입니다.

이렇게 타입을 나눠서 진행하는 이유는 TextView가 TextField와는 다르게 placeholder를 가지고 있지 않아서 입니다. 따라서 TextField처럼 구현되도록 하기 위해서 따로 enum 타입을 만들어두고 진행했습니다.

```swift
enum TextMode {
        case beforeWriting
        case write
        case complete

        var placeholder: String? { }

        var textColor: UIColor { }
}
```

<br>

### ☑️ Keyboard가 올라가고 내려감에 따라서 NotificationCenter로 관리합니다.

#91 에서도 동일하게 구현한 적 있는 코드입니다. 

```swift
private func setupNotificationCenter() {
        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
    }
```

NotificationCenter에서 UIResponder.keyboardWillShowNotification, UIResponder.keyboardWillHideNotification인 상황일 때 각각 keyboardWillShow, keyboardWillHide func이 실행되도록 구현했습니다.

* keyword가 올라갔을 때 -> keyboardWillShow

```swift
@objc
  private func keyboardWillShow(_ notification: NSNotification) {
      if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
          let keyboardRectangle = keyboardFrame.cgRectValue
          let keyboardHeight = keyboardRectangle.height

          self.textViewConstraint?[.bottom]?.constant = -keyboardHeight
      }
  }
```

* keyword가 내려갔을 때 -> keyboardWillHide

```swift
@objc
  private func keyboardWillHide(_ notification: NSNotification) {
      self.textViewConstraint?[.bottom]?.constant = -Size.backgroundSpacing
  }
```

keyword가 올라가고 내려갈 때 TextView .bottom Constraint를 변경하도록 구현했습니다.

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

https://user-images.githubusercontent.com/55099365/202651288-024e11fd-78e7-42fc-a206-ec4d32403fe5.mov

### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
