### PR TITLE
[FEAT] 중심 문장 뷰에서 중심 문장을 선택하는 기능을 구현했습니다.

### DIFF
--- a/EarthValley80/EarthValley80/Global/Extensions/UILabel+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UILabel+Extension.swift
@@ -62,4 +62,30 @@ extension UILabel {
         
         self.attributedText = attributedString
     }
+
+    func textIndex(at point: CGPoint) -> Int? {
+        guard let attributedText = attributedText else { return nil }
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: self.bounds.size)
+        let textStorage = NSTextStorage(attributedString: attributedText)
+
+        textContainer.lineFragmentPadding = 0.0
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+
+        let range = layoutManager.glyphRange(for: textContainer)
+        let textBounds = layoutManager.boundingRect(forGlyphRange: range,
+                                                    in: textContainer)
+        let paddingWidth = (self.bounds.size.width - textBounds.size.width) / 2
+        var textOffset = CGPoint.zero
+
+        if paddingWidth > 0 {
+            textOffset.x = paddingWidth
+        }
+
+        let newPoint = CGPoint(x: point.x - textOffset.x,
+                               y: point.y - textOffset.y)
+
+        return layoutManager.glyphIndex(for: newPoint, in: textContainer)
+    }
 }

--- a/EarthValley80/EarthValley80/Global/Extensions/UILabel+Extension.swift
+++ b/EarthValley80/EarthValley80/Global/Extensions/UILabel+Extension.swift
@@ -64,7 +64,7 @@ extension UILabel {
     }
 
     func textIndex(at point: CGPoint) -> Int? {
-        guard let attributedText = attributedText else { return nil }
+        guard let attributedText = self.attributedText else { return nil }
         let layoutManager = NSLayoutManager()
         let textContainer = NSTextContainer(size: self.bounds.size)
         let textStorage = NSTextStorage(attributedString: attributedText)

--- a/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
+++ b/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         self.window?.backgroundColor = .systemBackground
-        self.window?.rootViewController = SideTabbarViewController()
+        self.window?.rootViewController = MainSentenceViewController()
         self.window?.makeKeyAndVisible()
     }
     

--- a/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
+++ b/EarthValley80/EarthValley80/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         self.window?.backgroundColor = .systemBackground
-        self.window?.rootViewController = MainSentenceViewController()
+        self.window?.rootViewController = SideTabbarViewController()
         self.window?.makeKeyAndVisible()
     }
     

--- a/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
@@ -158,10 +158,10 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         let _ = content.components(separatedBy: [".", "!", "?"])
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-            .compactMap { self.applyPunctuationMark(in: $0) }
-            .map { sentence in
-                let closedRange = self.findRangeOfSentence(sentence)
-                self.sentences[closedRange] = sentence
+            .compactMap { sentence in
+                guard let completionSentence = self.applyPunctuationMark(in: sentence) else { return }
+                let closedRange = self.findRangeOfSentence(completionSentence)
+                self.sentences[closedRange] = completionSentence
             }
     }
 
@@ -215,81 +215,5 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
                 break
             }
         }
-
-//        let subTextRect = self.contentLabel.boundingRectForCharacterRange(subText: "글자를 새긴 차")
-//        let rect = UIView(frame: subTextRect!)
-//        rect.backgroundColor = .red
-//        self.contentView.addSubview(rect)
-    }
-}
-
-extension UILabel {
-    func textIndex(at point: CGPoint) -> Int? {
-        guard let attributedText = attributedText else { return nil }
-
-        let layoutManager = NSLayoutManager()
-        let textContainer = NSTextContainer(size: self.bounds.size)
-        let textStorage = NSTextStorage(attributedString: attributedText)
-
-        textStorage.addLayoutManager(layoutManager)
-        textContainer.lineFragmentPadding = 0.0
-        layoutManager.addTextContainer(textContainer)
-
-        var textOffset = CGPoint.zero
-        // 정확한 자체(glyph)의 범위를 구하고 그 범위의 CGRect 값을 구합니다.
-        let range = layoutManager.glyphRange(for: textContainer)
-        let textBounds = layoutManager.boundingRect(
-            forGlyphRange: range,
-            in: textContainer
-        )
-
-        // textOffset.x가 패딩을 제외한 부분부터 시작하도록 합니다.
-        let paddingWidth = (self.bounds.size.width - textBounds.size.width) / 2
-        if paddingWidth > 0 {
-            textOffset.x = paddingWidth
-        }
-
-        // 눌려진 정확한 포인트를 구합니다.
-        let newPoint = CGPoint(
-            x: point.x - textOffset.x,
-            y: point.y - textOffset.y
-        )
-
-        // textContainer내에서 newPoint 위치의 glyph index를 반환합니다
-        return layoutManager.glyphIndex(for: newPoint, in: textContainer)
-    }
-
-    func boundingRectForCharacterRange(subText: String) -> CGRect? {
-        guard let attributedText = attributedText else { return nil }
-        guard let text = self.text else { return nil }
-
-        // 전체 텍스트(text)에서 subText만큼의 range를 구합니다.
-        guard let subRange = text.range(of: subText) else { return nil }
-        let range = NSRange(subRange, in: text)
-
-        // attributedText를 기반으로 한 NSTextStorage를 선언하고 NSLayoutManager를 추가합니다.
-        let layoutManager = NSLayoutManager()
-        let textStorage = NSTextStorage(attributedString: attributedText)
-        textStorage.addLayoutManager(layoutManager)
-
-        // instrinsicContentSize를 기반으로 NSTextContainer를 선언하고
-        let textContainer = NSTextContainer(size: intrinsicContentSize)
-        // 정확한 CGRect를 구해야하므로 padding 값은 0을 줍니다.
-        textContainer.lineFragmentPadding = 0.0
-        // layoutManager에 추가합니다.
-        layoutManager.addTextContainer(textContainer)
-
-        var glyphRange = NSRange()
-        // 주어진 범위(rage)에 대한 실질적인 glyphRange를 구합니다.
-        layoutManager.characterRange(
-            forGlyphRange: range,
-            actualGlyphRange: &glyphRange
-        )
-
-        // textContainer 내의 지정된 glyphRange에 대한 CGRect 값을 반환합니다.
-        return layoutManager.boundingRect(
-            forGlyphRange: glyphRange,
-            in: textContainer
-        )
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
@@ -63,6 +63,15 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
                 return .regular
             }
         }
+
+        var isUserInteractionEnabled: Bool {
+            switch self {
+            case .highlighted:
+                return true
+            case .original:
+                return false
+            }
+        }
     }
 
     // MARK: - property
@@ -86,6 +95,8 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         label.font = TextStyle.content(.original).font
         return label
     }()
+
+    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.didTappedView(_:)))
 
     // MARK: - init
 
@@ -125,6 +136,8 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
     private func configureUI() {
         self.backgroundColor = .clear
         self.selectionStyle = .none
+
+        self.contentLabel.addGestureRecognizer(tapGestureRecognizer)
     }
 
     private func setupParagraphStyle(to paragraphType: ParagraphType) {
@@ -132,6 +145,7 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         self.contentLabel.font = TextStyle.content(paragraphType).font
         self.captionLabel.textColor = paragraphType.textColor
         self.contentLabel.textColor = paragraphType.textColor
+        self.contentLabel.isUserInteractionEnabled = paragraphType.isUserInteractionEnabled
     }
 
     func setupContentParagraphData(paragraphIndex: Int, content: String) {
@@ -139,5 +153,12 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         self.contentLabel.text = content
         self.contentLabel.setLineSpacing(kernValue: -2.0,
                                          lineHeightMultiple: Size.minimumLineHeightMultiple)
+    }
+
+    // MARK: - selector
+
+    @objc
+    private func didTappedView(_ gestureRecognizer: UITapGestureRecognizer) {
+        print("탭탭")
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
@@ -74,6 +74,8 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         }
     }
 
+    var didTappedMainSentence: ((String) -> ())?
+
     // MARK: - property
 
     override var isSelected: Bool {
@@ -209,11 +211,10 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
             let closedRange = sentence.key
 
             if closedRange.contains(selectedIndex) {
-                print(sentence.value)
+                self.didTappedMainSentence?(sentence.value)
                 break
             }
         }
-
 
 //        let subTextRect = self.contentLabel.boundingRectForCharacterRange(subText: "글자를 새긴 차")
 //        let rect = UIView(frame: subTextRect!)

--- a/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
@@ -98,6 +98,8 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
 
     private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.didTappedView(_:)))
 
+    private var sentences: [ClosedRange<Int>: String] = [:]
+
     // MARK: - init
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -148,17 +150,139 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         self.contentLabel.isUserInteractionEnabled = paragraphType.isUserInteractionEnabled
     }
 
+    private func appendSentences() {
+        guard let content = self.contentLabel.text else { return }
+
+        let _ = content.components(separatedBy: [".", "!", "?"])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .compactMap { self.applyPunctuationMark(in: $0) }
+            .map { sentence in
+                let closedRange = self.findRangeOfSentence(sentence)
+                self.sentences[closedRange] = sentence
+            }
+    }
+
+    private func applyPunctuationMark(in sentence: String) -> String? {
+        let separatorCharacters: [String] = [".", "?", "!"]
+        let sentencesWithCharacter = separatorCharacters.map({ "\(sentence)\($0)" })
+
+        for sentence in sentencesWithCharacter {
+            if let hasSentence = self.contentLabel.text?.contains(sentence),
+               hasSentence {
+                return sentence
+            }
+        }
+
+        return nil
+    }
+
+    private func findRangeOfSentence(_ sentence: String) -> ClosedRange<Int> {
+        guard let content = self.contentLabel.text else { return 0...0 }
+        let range = content.range(of: sentence)
+
+        guard
+            let lowerBound = range?.lowerBound.utf16Offset(in: content),
+            let upperBound = range?.upperBound.utf16Offset(in: content)
+        else { return 0...0 }
+
+        return lowerBound...upperBound
+    }
+
     func setupContentParagraphData(paragraphIndex: Int, content: String) {
         self.captionLabel.text = paragraphIndex.description
         self.contentLabel.text = content
         self.contentLabel.setLineSpacing(kernValue: -2.0,
                                          lineHeightMultiple: Size.minimumLineHeightMultiple)
+        self.appendSentences()
     }
 
     // MARK: - selector
 
     @objc
     private func didTappedView(_ gestureRecognizer: UITapGestureRecognizer) {
-        print("탭탭")
+        guard gestureRecognizer.state == UIGestureRecognizer.State.recognized else { return }
+        let gesturePoint = gestureRecognizer.location(in: gestureRecognizer.view)
+        guard let selectedIndex = self.contentLabel.textIndex(at: gesturePoint) else { return }
+        print(selectedIndex)
+
+
+//        let subTextRect = self.contentLabel.boundingRectForCharacterRange(subText: "글자를 새긴 차")
+//        let rect = UIView(frame: subTextRect!)
+//        rect.backgroundColor = .red
+//        self.contentView.addSubview(rect)
+    }
+}
+
+extension UILabel {
+    /// 입력된 포지션에 따라 라벨의 문자열의 인덱스 반환
+    /// - Parameter point: 인덱스 값을 알고 싶은 CGPoint
+    func textIndex(at point: CGPoint) -> Int? {
+        guard let attributedText = attributedText else { return nil }
+
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: self.bounds.size)
+        let textStorage = NSTextStorage(attributedString: attributedText)
+
+        textStorage.addLayoutManager(layoutManager)
+        textContainer.lineFragmentPadding = 0.0
+        layoutManager.addTextContainer(textContainer)
+
+        var textOffset = CGPoint.zero
+        // 정확한 자체(glyph)의 범위를 구하고 그 범위의 CGRect 값을 구합니다.
+        let range = layoutManager.glyphRange(for: textContainer)
+        let textBounds = layoutManager.boundingRect(
+            forGlyphRange: range,
+            in: textContainer
+        )
+
+        // textOffset.x가 패딩을 제외한 부분부터 시작하도록 합니다.
+        let paddingWidth = (self.bounds.size.width - textBounds.size.width) / 2
+        if paddingWidth > 0 {
+            textOffset.x = paddingWidth
+        }
+
+        // 눌려진 정확한 포인트를 구합니다.
+        let newPoint = CGPoint(
+            x: point.x - textOffset.x,
+            y: point.y - textOffset.y
+        )
+
+        // textContainer내에서 newPoint 위치의 glyph index를 반환합니다
+        return layoutManager.glyphIndex(for: newPoint, in: textContainer)
+    }
+
+    func boundingRectForCharacterRange(subText: String) -> CGRect? {
+        guard let attributedText = attributedText else { return nil }
+        guard let text = self.text else { return nil }
+
+        // 전체 텍스트(text)에서 subText만큼의 range를 구합니다.
+        guard let subRange = text.range(of: subText) else { return nil }
+        let range = NSRange(subRange, in: text)
+
+        // attributedText를 기반으로 한 NSTextStorage를 선언하고 NSLayoutManager를 추가합니다.
+        let layoutManager = NSLayoutManager()
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        textStorage.addLayoutManager(layoutManager)
+
+        // instrinsicContentSize를 기반으로 NSTextContainer를 선언하고
+        let textContainer = NSTextContainer(size: intrinsicContentSize)
+        // 정확한 CGRect를 구해야하므로 padding 값은 0을 줍니다.
+        textContainer.lineFragmentPadding = 0.0
+        // layoutManager에 추가합니다.
+        layoutManager.addTextContainer(textContainer)
+
+        var glyphRange = NSRange()
+        // 주어진 범위(rage)에 대한 실질적인 glyphRange를 구합니다.
+        layoutManager.characterRange(
+            forGlyphRange: range,
+            actualGlyphRange: &glyphRange
+        )
+
+        // textContainer 내의 지정된 glyphRange에 대한 CGRect 값을 반환합니다.
+        return layoutManager.boundingRect(
+            forGlyphRange: glyphRange,
+            in: textContainer
+        )
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/MainContentParagraphTableViewCell.swift
@@ -204,7 +204,15 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
         guard gestureRecognizer.state == UIGestureRecognizer.State.recognized else { return }
         let gesturePoint = gestureRecognizer.location(in: gestureRecognizer.view)
         guard let selectedIndex = self.contentLabel.textIndex(at: gesturePoint) else { return }
-        print(selectedIndex)
+
+        for sentence in self.sentences {
+            let closedRange = sentence.key
+
+            if closedRange.contains(selectedIndex) {
+                print(sentence.value)
+                break
+            }
+        }
 
 
 //        let subTextRect = self.contentLabel.boundingRectForCharacterRange(subText: "글자를 새긴 차")
@@ -215,8 +223,6 @@ final class MainContentParagraphTableViewCell: UITableViewCell {
 }
 
 extension UILabel {
-    /// 입력된 포지션에 따라 라벨의 문자열의 인덱스 반환
-    /// - Parameter point: 인덱스 값을 알고 싶은 CGPoint
     func textIndex(at point: CGPoint) -> Int? {
         guard let attributedText = attributedText else { return nil }
 

--- a/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
@@ -81,7 +81,11 @@ final class MainSentenceView: UIView {
             self.sentences = Array(repeating: "", count: newValue)
         }
     }
-    private var sentences: [String]?
+    private var sentences: [String]? {
+        didSet {
+            self.sentenceTableView.reloadData()
+        }
+    }
 
     // MARK: - init
 
@@ -135,6 +139,10 @@ final class MainSentenceView: UIView {
             self.titleLabel.text = title
             self.titleLabel.setLineSpacing(kernValue: -1.0)
         }
+    }
+
+    func putMainSentence(at index: Int, sentence: String) {
+        self.sentences?[index] = sentence
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
@@ -75,6 +75,14 @@ final class MainSentenceView: UIView {
         return label
     }()
 
+    var paragraphNumber: Int? {
+        willSet {
+            guard let newValue = newValue else { return }
+            self.sentences = Array(repeating: "", count: newValue)
+        }
+    }
+    private var sentences: [String]?
+
     // MARK: - init
 
     init(type: ViewType) {
@@ -133,15 +141,18 @@ final class MainSentenceView: UIView {
 // MARK: - UITableViewDataSource
 extension MainSentenceView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        guard let sentences = self.sentences else { return 0 }
+        return sentences.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: MainSentenceTableViewCell = tableView.dequeueReusableCell(withType: MainSentenceTableViewCell.self, for: indexPath)
-        let paragraphIndex = indexPath.row + 1
-
-        // TODO: - 나중에 배열을 생성해서 중심문장을 받을 생각입니다.
-        cell.setupCellData(index: paragraphIndex, content: "페이스북의 모회사(회사의 경영을 지배하는 회사)인 메타가 직원 1만1000명을 해고한다고 밝혔다.")
+        
+        if let sentences = self.sentences {
+            let paragraphIndex = indexPath.row + 1
+            
+            cell.setupCellData(index: paragraphIndex, content: sentences[indexPath.row])
+        }
 
         return cell
     }

--- a/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
@@ -143,6 +143,7 @@ final class MainSentenceView: UIView {
 
     func putMainSentence(at index: Int, sentence: String) {
         self.sentences?[index] = sentence
+        self.sentenceTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: .top, animated: true)
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
@@ -126,6 +126,9 @@ extension MainSentenceViewController: UITableViewDataSource {
 
         // TODO: - content 내용 나누는 부분은 후에 적용할 예정
         cell.setupContentParagraphData(paragraphIndex: paragraphIndex, content: "          ‘타다’는 승합차를 유료로 타려는 이용자와 운전자를 연결해주는 차량공유 앱 서비스입니다. 승합차는 일반 택시보다 크고 마을버스보다 작은 차종을 말합니다. 대개 11~15인승입니다. 2018년 10월 ‘타다’라는 글자를 새긴 차가 처음 시장에 등장했습니다.")
+        cell.didTappedMainSentence = { [weak self] sentence in
+            self?.mainSentenceView.putMainSentence(at: indexPath.row, sentence: sentence)
+        }
 
         if enteredFirstTime {
             self.enteredViewFirstTime = false

--- a/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
@@ -53,11 +53,16 @@ final class MainSentenceViewController: UIViewController {
         return view
     }()
     private let titleView: CapsuleFormTitleView = CapsuleFormTitleView(title: StringLiteral.mainSentenceTitle)
-    private let mainSentenceView = MainSentenceView(type: .mainSentence)
     private let backButton = BackButton()
+    private lazy var mainSentenceView: MainSentenceView = {
+        let view = MainSentenceView(type: .mainSentence)
+        view.paragraphNumber = self.sentences.count
+        return view
+    }()
 
     private var enteredViewFirstTime: Bool = true
-    private var sentences: [String] = []
+    // TODO: - 일단 빈 스트링으로 생성, 후에 채우는 로직 넣기
+    private var sentences: [String] = ["", "", "", "", ""]
     
     // MARK: - life cycle
 
@@ -111,7 +116,7 @@ final class MainSentenceViewController: UIViewController {
 // MARK: - UITableViewDataSource
 extension MainSentenceViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return self.sentences.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #143 

## ⚫️  변경사항
<!-- 의존성 목록 -->
- 변경 사항은 없습니다.

## ⚫️  새로운 기능
<!-- 기능 목록 -->

### ☑️ 하이라이트 됐을 때는 셀 내용이 눌리고 아닐때는 셀이 눌리도록 구현했습니다.

일단 셀 내부에 있는 UILabel에 Tap Gesture를 줬어요. 해당 제스처는 Label에만 붙어있습니다. 
근데 항상 Gesture가 들어있게 된다면 셀 터치가 안될겁니다. Gesture를 누른 것으로 판단을 해서 UILabel를 터치했다고 생각하거든요.

따라서 이런 문제를 해결하기 위해서 하이라이트 시엔 `isUserInteractionEnabled`값을 true로 하고 아닐시에는 `isUserInteractionEnabled`값을 false로 줬습니다. 해당 값이 false라면 해당 gesture가 사용자와 인터렉션할 마음이 없다라고 판단을 해서 제스처가 먹히지 않거든요. 

이런식으로 터치를 구현했습니다.

<br>

### ☑️ 중심 문장을 UILabel로부터 가져오는 기능을 구현했습니다.

[어쩌다가 듀나가 코드를 저렇게 짜게 되었는가...?](https://yxxnaxxin.notion.site/UITapGestureRecognizer-UILabel-8045b72bf990427c8d29f1718183e4a2) 에 대한 노션 게시글 입니다. 나중에 시간이 되면 discussion으로 더 간결하고 읽기 쉽게 정리해두겠습니다. 지금은 당장 진행하면서 공부한거라 정리가 안되어 있어요..👀

네 줄 요약을 해보자면,

1. Cell에 단락을 넣을 때, 들어간 단락을 문장으로 다 나눠버림
2. 나눠진 문장과 UILabel text에서 해당 문장의 시작과 끝 index가 몇인지 dictionary 형태로 저장
3. UILabel를 눌렀을 때 text index를 가져오도록 해서 해당 index가 어느 문장의 range에 속하는 지 확인
4. 속하는 range가 있다면 문장을 중심 문장 뷰에 넣음

입니다.

`appendSentences`, `applyPunctuationMark`, `findRangeOfSentence` 함수를 중점적으로 보시면 됩니다.
세 함수에 네 줄 요약에 있는 기능이 다 들어있습니다. 해당 함수들은 나중에 서버 통신을 위해서 Model 를 만들게 되면 그 안에다가 넣어줄 생각입니다. 

```swift
    private func appendSentences() {
        guard let content = self.contentLabel.text else { return }

        let _ = content.components(separatedBy: [".", "!", "?"])
            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
            .filter { !$0.isEmpty }
            .compactMap { sentence in
                guard let completionSentence = self.applyPunctuationMark(in: sentence) else { return }
                let closedRange = self.findRangeOfSentence(completionSentence)
                self.sentences[closedRange] = completionSentence
            }
    }

    private func applyPunctuationMark(in sentence: String) -> String? {
        let separatorCharacters: [String] = [".", "?", "!"]
        let sentencesWithCharacter = separatorCharacters.map({ "\(sentence)\($0)" })

        for sentence in sentencesWithCharacter {
            if let hasSentence = self.contentLabel.text?.contains(sentence),
               hasSentence {
                return sentence
            }
        }

        return nil
    }

    private func findRangeOfSentence(_ sentence: String) -> ClosedRange<Int> {
        guard let content = self.contentLabel.text else { return 0...0 }
        let range = content.range(of: sentence)

        guard
            let lowerBound = range?.lowerBound.utf16Offset(in: content),
            let upperBound = range?.upperBound.utf16Offset(in: content)
        else { return 0...0 }

        return lowerBound...upperBound
    }
```

<br>

### ☑️ 선택된 문장은 어떻게 중심 문장 뷰로 이동하나요?

선택된 문장이 중심 문장 뷰로 이동하는 방식은 

1. `MainContentParagraphTableViewCell`에서 문장이 터치되었을 때 `didTappedMainSentence` 클로저 함수가 불리게 됩니다. 해당 클로저는 String를 return합니다. 그 String이 문장이겠죠?

2. return 되는 부분은 `MainSentenceViewController`입니다. 문장이 didTappedMainSentence를 통해서 들어옵니다.
    ```swift
        cell.didTappedMainSentence = { [weak self] sentence in
            self?.mainSentenceView.putMainSentence(at: indexPath.row, sentence: sentence)
        }
    ```
3. 위의 코드에서 나와있다시피 `mainSentenceView`로 문장이 이동합니다. putMainSentence라는 메소드를 통해서 지금 이 문장이 속해있는 indexPath.row과 sentence를 한 번에 보냅니다.
4. sentence가 중심 문장 뷰에서 보이게 됩니다.

<br>

이번 PR은 위의 내용이 중심이었던 PR이라서 위의 세 개의 내용만 이해하시면 됩니다!
중심 내용이 보이는 부분이 하나씩 만들어져야 하는데, 지금 UI를 디자인처럼 만드는 것은 후순위라서 뒤로 미루겠습니다. 🥲
일단은 기능만 봐주세요!

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

https://user-images.githubusercontent.com/55099365/203285016-d994bdba-a237-4d8e-9d91-d48105772742.mov


### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
