### PR TITLE
[FEAT] 요모조모 뉴스 부분에서 기사를 눌렀을 때 News 뷰로 데이터가 이어지는 플로우를 구현했습니다.

### DIFF
--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		B5BE347B28FD9E5500D09BEE /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347A28FD9E5500D09BEE /* UIViewController+Alert.swift */; };
 		B5BE347E28FDA22F00D09BEE /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347D28FDA22F00D09BEE /* ImageLiteral.swift */; };
 		B5BE348028FDA2A200D09BEE /* StringLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BE347F28FDA2A200D09BEE /* StringLiteral.swift */; };
+		B5E8FB1C292DBC42004A187E /* NewsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E8FB1B292DBC42004A187E /* NewsManager.swift */; };
 		B5FAC8DC2907652800537F58 /* ReadingNewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8DB2907652800537F58 /* ReadingNewsViewController.swift */; };
 		B5FAC8DF2907786F00537F58 /* NewsTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8DE2907786F00537F58 /* NewsTitleView.swift */; };
 		B5FAC8E2290781C200537F58 /* NewsContentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAC8E1290781C200537F58 /* NewsContentTableViewCell.swift */; };
@@ -160,6 +161,7 @@
 		B5BE347A28FD9E5500D09BEE /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		B5BE347D28FDA22F00D09BEE /* ImageLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		B5BE347F28FDA2A200D09BEE /* StringLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiteral.swift; sourceTree = "<group>"; };
+		B5E8FB1B292DBC42004A187E /* NewsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsManager.swift; sourceTree = "<group>"; };
 		B5FAC8DB2907652800537F58 /* ReadingNewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingNewsViewController.swift; sourceTree = "<group>"; };
 		B5FAC8DE2907786F00537F58 /* NewsTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTitleView.swift; sourceTree = "<group>"; };
 		B5FAC8E1290781C200537F58 /* NewsContentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsContentTableViewCell.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 		B5BE345528FD96C700D09BEE /* News */ = {
 			isa = PBXGroup;
 			children = (
+				B5E8FB1A292DBC39004A187E /* Manager */,
 				B5FAC8E0290781AD00537F58 /* Cells */,
 				B5FAC8DD2907785D00537F58 /* Components */,
 				B5FAC8DB2907652800537F58 /* ReadingNewsViewController.swift */,
@@ -473,6 +476,14 @@
 				B5BE347F28FDA2A200D09BEE /* StringLiteral.swift */,
 			);
 			path = Literals;
+			sourceTree = "<group>";
+		};
+		B5E8FB1A292DBC39004A187E /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				B5E8FB1B292DBC42004A187E /* NewsManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		B5FAC8DD2907785D00537F58 /* Components */ = {
@@ -729,6 +740,7 @@
 				B5BE346428FD986600D09BEE /* YomojomoNewsViewController.swift in Sources */,
 				B5FAC8E2290781C200537F58 /* NewsContentTableViewCell.swift in Sources */,
 				B589F37E292AF1E7008468A8 /* MainContentParagraphTableViewCell.swift in Sources */,
+				B5E8FB1C292DBC42004A187E /* NewsManager.swift in Sources */,
 				B50E7A4A292604DD009D8410 /* CapsuleFormTitleView.swift in Sources */,
 				CDE23AA4290ABCAE00EEB824 /* TabbarButtonView.swift in Sources */,
 				B5FAC8EF2907D2A300537F58 /* BackButton.swift in Sources */,

--- a/EarthValley80/EarthValley80/Screen/News/Cells/NewsContentTableViewCell.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Cells/NewsContentTableViewCell.swift
@@ -31,28 +31,19 @@ final class NewsContentTableViewCell: UITableViewCell {
     
     // MARK: - property
     
-    private let contentLabel: UILabel = {
+    private lazy var contentLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         label.textColor = .expandedTextColor
         label.font = .font(.regular, ofSize: Size.originalFontSize)
-        
-        // TODO: - 더미 데이터, 나중에 지우겠습니다.
-        label.text = """
-        ‘타다’는 승합차를 유료로 타려는 이용자와 운전자를 연결해주는 차량공유 앱 서비스입니다. 승합차는 일반 택시보다 크고 마을버스보다 작은 차종을 말합니다. 대개 11~15인승입니다. 2018년 10월 ‘타다’라는 글자를 새긴 차가 처음 시장에 등장했습니다.
-        미국에서 차량공유 서비스인 ‘우버’가 주목받은 터여서 타다는 한국식 우버로 불리기도 했습니다.
-
-        문제가 발생했습니다. 택시업계가 반발한 겁니다. “택시 면허가 없는 사람들이 택시 영업을 한다”고 주장했고 수사당국인 검찰이 1년 뒤인 2019년 10월 타다 운영업체 VCNC의 박재욱 대표와 모기업 쏘카의 이재웅 대표를 재판에 넘겼습니다. 1심과 2심 법원은 모두 ‘타다 무죄’를 선고했습니다.
-        ‘모바일 앱과 승합차를 잇는 혁신 서비스’인지, ‘무면허 택시 영업행위’인지를 놓고 양측이 3년간 치열하게 싸웠습니다.
-
-        누가 재판에 이겼느냐는 우리의 관심사가 아닙니다. 타다 재판의 이면에 웅크리고 있는 생각들에 주목해야 합니다. 혁신과 기득권의 대립, 새로운 것과 기존에 있던 것 사이의 충돌, 현재와 미래, 진화와 도태 같은 이슈들이죠.
-        """
+        label.text = self.newsManager.newsContent
         label.setLineSpacing(kernValue: -2.0,
                              lineHeightMultiple: Size.originalLineHeightMultiple)
 
         return label
     }()
-    
+
+    private let newsManager = NewsManager.shared
     private var sentences: [String] = []
     private var readingIndex: Int = -1
 

--- a/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
@@ -141,9 +141,11 @@ final class MainSentenceView: UIView {
         }
     }
 
-    func putMainSentence(at index: Int, sentence: String) {
+    func putMainSentence(at index: Int,
+                         sentence: String,
+                         scrollPosition: UITableView.ScrollPosition = .top) {
         self.sentences?[index] = sentence
-        self.sentenceTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: .top, animated: true)
+        self.sentenceTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: scrollPosition, animated: true)
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/MainSentenceView.swift
@@ -51,7 +51,7 @@ final class MainSentenceView: UIView {
 
     // MARK: - property
 
-    private lazy var sentenceTableView: UITableView = {
+    private(set) lazy var sentenceTableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.dataSource = self
         tableView.separatorColor = .clear
@@ -141,11 +141,9 @@ final class MainSentenceView: UIView {
         }
     }
 
-    func putMainSentence(at index: Int,
-                         sentence: String,
-                         scrollPosition: UITableView.ScrollPosition = .top) {
+    func putMainSentence(at index: Int, sentence: String) {
         self.sentences?[index] = sentence
-        self.sentenceTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: scrollPosition, animated: true)
+        self.sentenceTableView.scrollToRow(at: IndexPath(row: index, section: 0), at: .top, animated: true)
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Components/NewsTitleView.swift
@@ -87,9 +87,7 @@ final class NewsTitleView: UIView {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        
-        // TODO: - 더미 데이터, 나중에 지우겠습니다.
-        label.text = "인류보다 로봇 진화 속도가 더 빠르대요, 청소로봇은 '루시'…생각하는 로봇 등장"
+        label.text = self.newsManager.newsTitle
         label.numberOfLines = 0
         label.font = .font(.bold, ofSize: self.status.fontSize)
         label.setLineSpacing(kernValue: -2.0, lineHeightMultiple: 1.16)
@@ -118,6 +116,8 @@ final class NewsTitleView: UIView {
         
         return label.frame.height + self.status.bottomSpacing
     }
+
+    private let newsManager = NewsManager.shared
     
     // MARK: - init
     

--- a/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
@@ -54,11 +54,7 @@ final class MainSentenceViewController: UIViewController {
     }()
     private let titleView: CapsuleFormTitleView = CapsuleFormTitleView(title: StringLiteral.mainSentenceTitle)
     private let backButton = BackButton()
-    private lazy var mainSentenceView: MainSentenceView = {
-        let view = MainSentenceView(type: .mainSentence)
-        view.paragraphNumber = self.sentences.count
-        return view
-    }()
+    private let mainSentenceView = MainSentenceView(type: .mainSentence)
     private lazy var nextButton: GotoSomewhereButton = {
         let button = GotoSomewhereButton(type: .white)
         let action = UIAction { [weak self] _ in
@@ -72,8 +68,11 @@ final class MainSentenceViewController: UIViewController {
     }()
 
     private var enteredViewFirstTime: Bool = true
-    // TODO: - 일단 빈 스트링으로 생성, 후에 채우는 로직 넣기
-    private var sentences: [String] = []
+    private var paragraphs: [String] = [] {
+        willSet {
+            self.mainSentenceView.paragraphNumber = newValue.count
+        }
+    }
     
     private let newsManager = NewsManager.shared
     
@@ -141,14 +140,14 @@ final class MainSentenceViewController: UIViewController {
     private func appendSentences() {
         let _ = self.newsManager.newsContent.components(separatedBy: CharacterSet.newlines)
                                             .filter { $0 != "" }
-                                            .compactMap { self.sentences.append($0) }
+                                            .compactMap { self.paragraphs.append($0) }
     }
 }
 
 // MARK: - UITableViewDataSource
 extension MainSentenceViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.sentences.count
+        return self.paragraphs.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -156,7 +155,7 @@ extension MainSentenceViewController: UITableViewDataSource {
         let paragraphIndex = indexPath.row + 1
         let enteredFirstTime = indexPath.row == 0 && self.enteredViewFirstTime
 
-        cell.setupContentParagraphData(paragraphIndex: paragraphIndex, content: self.sentences[indexPath.row])
+        cell.setupContentParagraphData(paragraphIndex: paragraphIndex, content: self.paragraphs[indexPath.row])
         cell.didTappedMainSentence = { [weak self] sentence in
             guard let mainSentenceView = self?.mainSentenceView else { return }
             mainSentenceView.putMainSentence(at: indexPath.row, sentence: sentence)

--- a/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
@@ -73,13 +73,16 @@ final class MainSentenceViewController: UIViewController {
 
     private var enteredViewFirstTime: Bool = true
     // TODO: - 일단 빈 스트링으로 생성, 후에 채우는 로직 넣기
-    private var sentences: [String] = ["", "", "", "", ""]
+    private var sentences: [String] = []
+    
+    private let newsManager = NewsManager.shared
     
     // MARK: - life cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setupLayout()
+        self.appendSentences()
     }
     
     // MARK: - func
@@ -134,6 +137,12 @@ final class MainSentenceViewController: UIViewController {
         summaryViewController.modalPresentationStyle = .fullScreen
         self.present(summaryViewController, animated: true)
     }
+
+    private func appendSentences() {
+        let _ = self.newsManager.newsContent.components(separatedBy: CharacterSet.newlines)
+                                            .filter { $0 != "" }
+                                            .compactMap { self.sentences.append($0) }
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -147,8 +156,7 @@ extension MainSentenceViewController: UITableViewDataSource {
         let paragraphIndex = indexPath.row + 1
         let enteredFirstTime = indexPath.row == 0 && self.enteredViewFirstTime
 
-        // TODO: - content 내용 나누는 부분은 후에 적용할 예정
-        cell.setupContentParagraphData(paragraphIndex: paragraphIndex, content: "          ‘타다’는 승합차를 유료로 타려는 이용자와 운전자를 연결해주는 차량공유 앱 서비스입니다. 승합차는 일반 택시보다 크고 마을버스보다 작은 차종을 말합니다. 대개 11~15인승입니다. 2018년 10월 ‘타다’라는 글자를 새긴 차가 처음 시장에 등장했습니다.")
+        cell.setupContentParagraphData(paragraphIndex: paragraphIndex, content: self.sentences[indexPath.row])
         cell.didTappedMainSentence = { [weak self] sentence in
             guard let mainSentenceView = self?.mainSentenceView else { return }
             mainSentenceView.putMainSentence(at: indexPath.row, sentence: sentence)

--- a/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MainSentenceViewController.swift
@@ -58,6 +58,7 @@ final class MainSentenceViewController: UIViewController {
     private lazy var nextButton: GotoSomewhereButton = {
         let button = GotoSomewhereButton(type: .white)
         let action = UIAction { [weak self] _ in
+            self?.newsManager.setupMainSentences(self?.mainSentenceView.sentences ?? [])
             self?.presentSummaryViewController()
         }
         button.addAction(action, for: .touchUpInside)

--- a/EarthValley80/EarthValley80/Screen/News/Manager/NewsManager.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Manager/NewsManager.swift
@@ -1,0 +1,34 @@
+//
+//  NewsManager.swift
+//  EarthValley80
+//
+//  Created by SHIN YOON AH on 2022/11/23.
+//
+
+import Foundation
+
+final class NewsManager {
+
+    static let shared = NewsManager()
+
+    // MARK: - property
+
+    private(set) var newsTitle: String = ""
+    private(set) var newsContent: String = ""
+
+    // MARK: - init
+
+    private init() { }
+
+    // MARK: - func
+
+    func resetAll() {
+        self.newsTitle = ""
+        self.newsContent = ""
+    }
+
+    func setupNews(title: String, content: String) {
+        self.newsTitle = title
+        self.newsContent = content
+    }
+}

--- a/EarthValley80/EarthValley80/Screen/News/Manager/NewsManager.swift
+++ b/EarthValley80/EarthValley80/Screen/News/Manager/NewsManager.swift
@@ -15,6 +15,7 @@ final class NewsManager {
 
     private(set) var newsTitle: String = ""
     private(set) var newsContent: String = ""
+    private(set) var mainSentences: [String] = []
 
     // MARK: - init
 
@@ -25,10 +26,15 @@ final class NewsManager {
     func resetAll() {
         self.newsTitle = ""
         self.newsContent = ""
+        self.mainSentences.removeAll()
     }
 
     func setupNews(title: String, content: String) {
         self.newsTitle = title
         self.newsContent = content
+    }
+
+    func setupMainSentences(_ sentences: [String]) {
+        self.mainSentences = sentences
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/MyMainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MyMainSentenceViewController.swift
@@ -30,6 +30,8 @@ final class MyMainSentenceViewController: UIViewController {
     }()
     private let mainSentenceView = MainSentenceView(type: .summary)
 
+    private let newsManager = NewsManager.shared
+
     // MARK: - life cycle
     
     override func viewDidLoad() {
@@ -37,6 +39,7 @@ final class MyMainSentenceViewController: UIViewController {
         self.setupLayout()
         self.configureUI()
         self.setupButtonAction()
+        self.setupMainSentences()
     }
 
     // MARK: - func
@@ -65,5 +68,12 @@ final class MyMainSentenceViewController: UIViewController {
         }
 
         self.closeButton.addAction(dismissAction, for: .touchUpInside)
+    }
+
+    private func setupMainSentences() {
+        self.mainSentenceView.paragraphNumber = self.newsManager.mainSentences.count
+        self.newsManager.mainSentences.enumerated().forEach { index, sentence in
+            self.mainSentenceView.putMainSentence(at: index, sentence: sentence, scrollPosition: .none)
+        }
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/MyMainSentenceViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/MyMainSentenceViewController.swift
@@ -73,7 +73,8 @@ final class MyMainSentenceViewController: UIViewController {
     private func setupMainSentences() {
         self.mainSentenceView.paragraphNumber = self.newsManager.mainSentences.count
         self.newsManager.mainSentences.enumerated().forEach { index, sentence in
-            self.mainSentenceView.putMainSentence(at: index, sentence: sentence, scrollPosition: .none)
+            self.mainSentenceView.putMainSentence(at: index, sentence: sentence)
         }
+        self.mainSentenceView.sentenceTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/ReactionViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/ReactionViewController.swift
@@ -16,11 +16,10 @@ final class ReactionViewController: UIViewController {
     // MARK: - property
 
     private let titleView: CapsuleFormTitleView = CapsuleFormTitleView(title: StringLiteral.reactionTitle)
-    private let headlineLabel: UILabel = {
+    private lazy var headlineLabel: UILabel = {
         let label = UILabel()
         label.font = .font(.bold, ofSize: 34)
-        // TODO: - 더미로 넣어둔 텍스트
-        label.text = "세상에 다람쥐가 없다고 무슨 문제야?"
+        label.text = self.newsManager.newsTitle
         label.textColor = .evyWhite
         return label
     }()
@@ -93,6 +92,8 @@ final class ReactionViewController: UIViewController {
 
         return button
     }()
+
+    private let newsManager = NewsManager.shared
 
     // MARK: - life cycle
 

--- a/EarthValley80/EarthValley80/Screen/News/SummaryCompletionViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryCompletionViewController.swift
@@ -26,8 +26,9 @@ final class SummaryCompletionViewController: UIViewController {
     }()
     private lazy var nextButton: GotoSomewhereButton = {
         let button = GotoSomewhereButton(type: .white)
-        let action = UIAction { _ in
+        let action = UIAction { [weak self] _ in
             guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+            self?.resetNewsData()
             sceneDelegate.navigateToMyNewsDrawerViewController()
         }
         button.addAction(action, for: .touchUpInside)
@@ -35,6 +36,8 @@ final class SummaryCompletionViewController: UIViewController {
         button.setupButtonContents(buttonImage: ImageLiteral.icArrowRight, buttonTitle: StringLiteral.goToNewsDrawerButtonText)
         return button
     }()
+
+    private let newsManager = NewsManager.shared
 
     // MARK: - life cycle
 
@@ -73,5 +76,9 @@ final class SummaryCompletionViewController: UIViewController {
     private func configureUI() {
         // TODO: - 컬러셋 정해지면 변경
         self.view.backgroundColor = .black.withAlphaComponent(0.94)
+    }
+
+    private func resetNewsData() {
+        self.newsManager.resetAll()
     }
 }

--- a/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/News/SummaryViewController.swift
@@ -134,7 +134,7 @@ final class SummaryViewController: UIViewController {
     private func presentSummaryCompletionViewController() {
         let completionViewController = SummaryCompletionViewController()
         completionViewController.modalTransitionStyle = .crossDissolve
-        completionViewController.modalPresentationStyle = .fullScreen
+        completionViewController.modalPresentationStyle = .overCurrentContext
         self.present(completionViewController, animated: true)
     }
 

--- a/EarthValley80/EarthValley80/Screen/YomojomoNews/YomojomoNewsViewController.swift
+++ b/EarthValley80/EarthValley80/Screen/YomojomoNews/YomojomoNewsViewController.swift
@@ -87,6 +87,7 @@ final class YomojomoNewsViewController: UIViewController {
     }()
 
     private let newsModel = NewsSortingManager()
+    private let newsManager = NewsManager.shared
     private lazy var newsData = self.newsModel.arrangeNewsData(yomojomoViewDummyData)
 
     // MARK: - life cycle
@@ -222,6 +223,8 @@ extension YomojomoNewsViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - UICollectionViewDelegate
 extension YomojomoNewsViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let index = indexPath.row
+        self.newsManager.setupNews(title: newsData[index].title ?? "", content: newsData[index].content ?? "")
         NotificationCenter.default.post(name: .presentReadingNews, object: nil)
     }
 }


### PR DESCRIPTION
## ⚫️  Issue Number
<!-- close #00 -->
- close #161 

## ⚫️  변경사항
<!-- 의존성 목록 -->

### ☑️ NewsManager를 사용해서 데이터를 이용할 수 있도록 구현했습니다.

한 번 들어온 뉴스 데이터는 바뀌지 않고 모든 뉴스 뷰에서 사용됩니다. 따라서 Singleton 형식으로 manager를 하나 만들어두고 해당 데이터를 여러 곳에서 사용할 수 있도록 구현했습니다.

처음 뷰에 들어올 때 메인 뷰에서 해당 기사 데이터를 저장합니다.
```swift
extension YomojomoNewsViewController: UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let index = indexPath.row
        self.newsManager.setupNews(title: newsData[index].title ?? "", content: newsData[index].content ?? "")
        NotificationCenter.default.post(name: .presentReadingNews, object: nil)
    }
}
```

저장된 데이터는 다른 뷰에서 manager 변수를 선언해두고 해당 매니저 변수에서 title, content를 빼서 사용합니다.
```swift
label.text = self.newsManager.newsContent
```

## ⚫️  새로운 기능
<!-- 기능 목록 -->

- Manager가 새로운 기능인데, 위에 설명했기 때문에 따로 설명하지 않을게요!

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

https://user-images.githubusercontent.com/55099365/203463260-1a00f2b6-642b-42ba-94ed-d3382c43ec92.mov


### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
