### PR TITLE
[CHORE] 스탬프 선택시 요모 코스튬 변경

### DIFF
--- a/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
+++ b/EarthValley80/EarthValley80.xcodeproj/project.pbxproj
@@ -277,14 +277,6 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
-		381AB42D290FB5CB00620635 /* Manager */ = {
-			isa = PBXGroup;
-			children = (
-				381AB42E290FB5EE00620635 /* NewsSortingManager.swift */,
-			);
-			path = Manager;
-			sourceTree = "<group>";
-		};
 		3846FBFB2918101E003784F3 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -319,20 +311,20 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
-		38EF7C632939CC3300347DE4 /* Cells */ = {
-			isa = PBXGroup;
-			children = (
-				38EF7C642939CC5200347DE4 /* MyNewsDrawerCollectionViewCell.swift */,
-			);
-			path = Cells;
-			sourceTree = "<group>";
-		};
 		38EF7C5F2938570600347DE4 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
 				381AB42E290FB5EE00620635 /* NewsSortingManager.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		38EF7C632939CC3300347DE4 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				38EF7C642939CC5200347DE4 /* MyNewsDrawerCollectionViewCell.swift */,
+			);
+			path = Cells;
 			sourceTree = "<group>";
 		};
 		B50E7A482925D15E009D8410 /* Font */ = {
@@ -859,7 +851,6 @@
 				CD938A8F2926FDEE0026641B /* SideTabbarEventManager.swift in Sources */,
 				B5FAC8EB2907BA6000537F58 /* UIFont+Extension.swift in Sources */,
 				B50E7A472925C072009D8410 /* ReactionViewController.swift in Sources */,
-				3851FC062912E5B400CF3E89 /* LeftAlignCollectionViewFlowLayout.swift in Sources */,
 				CD6CBB7E293FAA1F00342771 /* BadgeIGotView.swift in Sources */,
 				CD938AC0292C8FB10026641B /* ContainerViewController.swift in Sources */,
 				CD4AC941291DEF1A003D02E4 /* SideTabbarLottieView.swift in Sources */,

--- a/EarthValley80/EarthValley80/Global/UIComponent/GotoYomoRoomButton.swift
+++ b/EarthValley80/EarthValley80/Global/UIComponent/GotoYomoRoomButton.swift
@@ -28,8 +28,7 @@ struct GotoYomoRoomButton: View {
         }
         
         if isTapped {
-            YomoRoomView()
-                .transition(.move(edge: .leading))
+            
         }
     }
 }

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/ArticleProgressView/Component/EconomyArticleProgress.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/ArticleProgressView/Component/EconomyArticleProgress.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct EconomyArticleProgress: View {
+    @State var pushedStamp: Int = 2
+
     private var count = 30
     private let pebbleOn = "economyStamp"
     private let pebbleOff = "grayStamp"
@@ -50,6 +52,12 @@ struct EconomyArticleProgress: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 41.5, height: 47.5)
+                            .scaleEffect(self.pushedStamp == 1 ? 1.25 : 1.0, anchor: .center)
+                            .animation(.default)
+                            .onTapGesture {
+                                self.pushedStamp = 1
+                            }
+                            .offset(x: 0, y: self.pushedStamp == 1 ? -15 : 0)
                             .padding(EdgeInsets(top: 0, leading: 0, bottom: 12.5, trailing: 0))
                     }
                     .offset(x: 25, y: 0)
@@ -81,6 +89,12 @@ struct EconomyArticleProgress: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 41.5, height: 47.5)
+                            .scaleEffect(self.pushedStamp == 2 ? 1.25 : 1.0, anchor: .top)
+                            .animation(.default)
+                            .onTapGesture {
+                                self.pushedStamp = 2
+                            }
+                            .offset(x: 0, y: self.pushedStamp == 2 ? -20 : 0)
                             .padding(EdgeInsets(top: 0, leading: 0, bottom: 12.5, trailing: 0))
                     }
                     .offset(x: -50, y: 0)

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/ArticleProgressView/Component/ScienceArticleProgress.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/ArticleProgressView/Component/ScienceArticleProgress.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct ScienceArticleProgress: View {
     private var count = 0
-    private let pebbleOn = "scienceStamp"
+    private let pebbleOn = "economyStamp"
     private let pebbleOff = "grayStamp"
     private let badgeOn = "badgeStamp"
-    
+
     var body: some View {
         VStack(spacing: 22) {
             LazyVStack(spacing: 5) {
@@ -117,7 +117,7 @@ struct ScienceArticleProgress: View {
                     ZStack {
                         Image(count > 49 ? badgeOn : pebbleOff)
                             .frame(width: 57, height: 57)
-                        Image(count > 49 ? "scienceLv3" : "grayScienceLv3")
+                        Image(count > 49 ? "scienceLv3" : "graySceinceLv3")
                             .resizable()
                             .scaledToFit()
                             .frame(width: 41.5, height: 47.5)

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/Component/FlameStreak.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/Component/FlameStreak.swift
@@ -39,7 +39,7 @@ struct FlameStreak: View {
             else {
                 self.TapDate = nil
                 self.ButtonTapped = false
-                self.counter = 0
+                self.counter = 25
             }
         }
     }

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/Component/YomoCostume.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/Component/YomoCostume.swift
@@ -8,16 +8,25 @@
 import SwiftUI
 
 struct YomoCoustume: View {
+    @Binding var pushedStamp: Int
+
     var body: some View {
-        Image("economyLv2Yomo")
-            .resizable()
-            .scaledToFit()
-            .frame(width: 207, height: 297, alignment: .center)
+        if pushedStamp == 1 {
+            Image("economyLv1Yomo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 207, height: 297, alignment: .center)
+        } else if pushedStamp == 2 {
+            Image("economyLv2Yomo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 207, height: 297, alignment: .center)
+        }
     }
 }
 
 struct YomoCoustume_Previews: PreviewProvider {
     static var previews: some View {
-        YomoCoustume()
+        YomoCoustume(pushedStamp: .constant(2))
     }
 }

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/YomoCharacterView.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/YomoCharacterView/YomoCharacterView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct YomoCharacterView: View {
+    @Binding var pushedStamp: Int
+    
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 25)
@@ -22,7 +24,7 @@ struct YomoCharacterView: View {
                     FlameStreak()
                         .padding(EdgeInsets(top: 28, leading: 0, bottom: 30, trailing: 30.4))
                 }
-                YomoCoustume()
+                YomoCoustume(pushedStamp: $pushedStamp)
                     .padding(EdgeInsets(top: 0, leading: 63, bottom: 44, trailing: 48))
             }
         }
@@ -31,7 +33,7 @@ struct YomoCharacterView: View {
 
 struct YomoCharacterView_Previews: PreviewProvider {
     static var previews: some View {
-        YomoCharacterView()
+        YomoCharacterView(pushedStamp: .constant(2))
     }
 }
 

--- a/EarthValley80/EarthValley80/Screen/YomoRoom/YomoRoomView.swift
+++ b/EarthValley80/EarthValley80/Screen/YomoRoom/YomoRoomView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct YomoRoomView: View {
+    @Binding var pushedStamp: Int
     
     var body: some View {
         VStack(spacing: 0) {
@@ -15,13 +16,13 @@ struct YomoRoomView: View {
                 .font(.system(size: 15))
                 .padding(EdgeInsets(top: 24, leading: 0, bottom: 0, trailing: 0))
             HStack(alignment: .top, spacing: 0) {
-                YomoCharacterView()
+                YomoCharacterView(pushedStamp: $pushedStamp)
                     .padding(EdgeInsets(top: 25, leading: 50, bottom: 0, trailing: 0))
                 VStack(alignment: .leading) {
                     BadgeIGotView()
-                        .padding(EdgeInsets(top: 25, leading: 13, bottom: 60, trailing: 00))
+                        .padding(EdgeInsets(top: 25, leading: 13, bottom: 60, trailing: 60))
                     ArticleProgressView()
-                        .padding(EdgeInsets(top: 0, leading: 25, bottom: 0, trailing: 25))
+                        .padding(EdgeInsets(top: 0, leading: 25, bottom: 0, trailing: 60))
                 }
             }
         }
@@ -31,9 +32,9 @@ struct YomoRoomView: View {
 struct YomoRoomView_Previews: PreviewProvider {
     static var previews: some View {
         if #available(iOS 15.0, *) {
-            YomoRoomView().previewInterfaceOrientation(.landscapeRight)
+            YomoRoomView(pushedStamp: .constant(2)).previewInterfaceOrientation(.landscapeRight)
         } else {
-            // Fallback on earlier versions
+            YomoRoomView(pushedStamp: .constant(2))
         }
     }
 }


### PR DESCRIPTION
## ⚫️  Issue Number
- close #198 
<!-- close #00 -->

## ⚫️  변경사항
없습니다.

<!-- 의존성 목록 -->

## ⚫️  새로운 기능
1.  경제전문가 <-> 경제왕 스탬프를 클릭 가능하게 만들었습니다.
2. 스탬프 클릭시 클릭된 스탬프가 커집니다.
3. 경제전문가 클릭시 겨울 요모, 경제왕 클릭시 얼룩 요모가 코스튬으로 뜹니다.
<img width="327" alt="스크린샷 2022-12-11 오후 6 31 09" src="https://user-images.githubusercontent.com/66079439/206896269-39243d6e-ba3a-4dec-b5ae-0740f0a08974.png">
<img width="349" alt="스크린샷 2022-12-11 오후 6 32 26" src="https://user-images.githubusercontent.com/66079439/206896272-b8119d30-18c6-40ba-baa9-84a7273c72bc.png">
<!-- 기능 목록 -->

## ⚫️  참고 사항
<!-- 참고 영상, 이미지, 링크 -->

### ☑️  작업 유형
- [x]  신규 기능 추가
- [ ]  버그 수정
- [ ]  리펙토링
- [ ]  문서 업데이트

### ☑️  체크리스트
- [x]  Merge 하는 브랜치가 올바른가?
- [x]  코딩컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 없는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [ ]  변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ]  새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
